### PR TITLE
feat: Plugin System (Phase 1 MVP)

### DIFF
--- a/plugins/example-weather/index.ts
+++ b/plugins/example-weather/index.ts
@@ -1,0 +1,63 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+
+/**
+ * Example weather plugin for KinBot.
+ * Demonstrates how to create a plugin with tools, config, and HTTP permissions.
+ */
+export default function(ctx: any) {
+  const { apiKey, units = 'metric' } = ctx.config
+
+  return {
+    tools: {
+      get_weather: {
+        availability: ['main', 'sub-kin'] as const,
+        create: () =>
+          tool({
+            description: 'Get current weather for a location',
+            parameters: z.object({
+              location: z.string().describe('City name (e.g. "Paris" or "London,UK")'),
+            }),
+            execute: async ({ location }: { location: string }) => {
+              if (!apiKey) {
+                return { error: 'OpenWeatherMap API key not configured. Go to Settings > Plugins to configure it.' }
+              }
+
+              const url = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(location)}&units=${units}&appid=${apiKey}`
+
+              try {
+                const res = await ctx.http.fetch(url)
+                const data = await res.json() as any
+
+                if (data.cod !== 200) {
+                  return { error: data.message || 'Failed to fetch weather' }
+                }
+
+                return {
+                  location: data.name,
+                  country: data.sys?.country,
+                  temperature: data.main.temp,
+                  feels_like: data.main.feels_like,
+                  humidity: data.main.humidity,
+                  description: data.weather[0].description,
+                  wind_speed: data.wind.speed,
+                  units: units === 'metric' ? '°C' : '°F',
+                }
+              } catch (err: any) {
+                ctx.log.error({ err }, 'Weather API request failed')
+                return { error: err.message || 'Weather API request failed' }
+              }
+            },
+          }),
+      },
+    },
+
+    async activate() {
+      ctx.log.info('Example weather plugin activated')
+    },
+
+    async deactivate() {
+      ctx.log.info('Example weather plugin deactivated')
+    },
+  }
+}

--- a/plugins/example-weather/plugin.json
+++ b/plugins/example-weather/plugin.json
@@ -1,0 +1,26 @@
+{
+  "name": "example-weather",
+  "version": "1.0.0",
+  "description": "Get current weather for any location using OpenWeatherMap",
+  "author": "KinBot",
+  "license": "MIT",
+  "main": "index.ts",
+  "permissions": [
+    "http:api.openweathermap.org"
+  ],
+  "config": {
+    "apiKey": {
+      "type": "string",
+      "label": "OpenWeatherMap API Key",
+      "description": "Get a free key at https://openweathermap.org/api",
+      "required": true,
+      "secret": true
+    },
+    "units": {
+      "type": "select",
+      "label": "Temperature Units",
+      "options": ["metric", "imperial"],
+      "default": "metric"
+    }
+  }
+}

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -1187,6 +1187,29 @@
       "days": "d",
       "hours": "h",
       "minutes": "m"
+    },
+    "plugins": {
+      "title": "Plugins",
+      "description": "Manage plugins that extend KinBot with new tools, hooks, and integrations.",
+      "reload": "Reload",
+      "reloaded": "Plugins reloaded",
+      "enabled": "Plugin enabled",
+      "disabled": "Plugin disabled",
+      "error": "Error",
+      "by": "by",
+      "tools": "tools",
+      "hooks": "hooks",
+      "permissions": "permissions",
+      "viewPermissions": "View permissions",
+      "configure": "Configure",
+      "configureTitle": "Configure {{name}}",
+      "configureDescription": "Update the plugin settings below.",
+      "configSaved": "Plugin configuration saved",
+      "homepage": "Homepage",
+      "empty": {
+        "title": "No plugins installed",
+        "description": "Drop a plugin folder into the plugins/ directory and click Reload."
+      }
     }
   },
   "notifications": {

--- a/src/client/locales/fr.json
+++ b/src/client/locales/fr.json
@@ -1187,6 +1187,29 @@
       "days": "j",
       "hours": "h",
       "minutes": "m"
+    },
+    "plugins": {
+      "title": "Plugins",
+      "description": "Gérez les plugins qui ajoutent des outils, hooks et intégrations à KinBot.",
+      "reload": "Recharger",
+      "reloaded": "Plugins rechargés",
+      "enabled": "Plugin activé",
+      "disabled": "Plugin désactivé",
+      "error": "Erreur",
+      "by": "par",
+      "tools": "outils",
+      "hooks": "hooks",
+      "permissions": "permissions",
+      "viewPermissions": "Voir les permissions",
+      "configure": "Configurer",
+      "configureTitle": "Configurer {{name}}",
+      "configureDescription": "Modifiez les paramètres du plugin ci-dessous.",
+      "configSaved": "Configuration du plugin sauvegardée",
+      "homepage": "Page d'accueil",
+      "empty": {
+        "title": "Aucun plugin installé",
+        "description": "Déposez un dossier de plugin dans le répertoire plugins/ et cliquez sur Recharger."
+      }
     }
   },
   "notifications": {

--- a/src/client/pages/settings/PluginsSettings.tsx
+++ b/src/client/pages/settings/PluginsSettings.tsx
@@ -1,0 +1,377 @@
+import { useState, useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
+import { Button } from '@/client/components/ui/button'
+import { Switch } from '@/client/components/ui/switch'
+import { Input } from '@/client/components/ui/input'
+import { Label } from '@/client/components/ui/label'
+import { Badge } from '@/client/components/ui/badge'
+import { Textarea } from '@/client/components/ui/textarea'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/client/components/ui/select'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/client/components/ui/dialog'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/client/components/ui/collapsible'
+import { EmptyState } from '@/client/components/common/EmptyState'
+import { SettingsListSkeleton } from '@/client/components/common/SettingsListSkeleton'
+import { api, getErrorMessage } from '@/client/lib/api'
+import {
+  Plug,
+  RefreshCw,
+  Settings2,
+  ChevronDown,
+  AlertTriangle,
+  Shield,
+  Wrench,
+  Anchor,
+  ExternalLink,
+} from 'lucide-react'
+import type { PluginSummary, PluginConfigField } from '@/shared/types/plugin'
+
+export function PluginsSettings() {
+  const { t } = useTranslation()
+  const [plugins, setPlugins] = useState<PluginSummary[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+  const [reloading, setReloading] = useState(false)
+  const [configPlugin, setConfigPlugin] = useState<PluginSummary | null>(null)
+  const [configValues, setConfigValues] = useState<Record<string, any>>({})
+  const [saving, setSaving] = useState(false)
+
+  useEffect(() => {
+    fetchPlugins()
+  }, [])
+
+  const fetchPlugins = async () => {
+    try {
+      const data = await api.get<PluginSummary[]>('/plugins')
+      setPlugins(data)
+    } catch {
+      // ignore
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleToggle = async (name: string, enabled: boolean) => {
+    try {
+      if (enabled) {
+        await api.post(`/plugins/${name}/enable`)
+        toast.success(t('settings.plugins.enabled'))
+      } else {
+        await api.post(`/plugins/${name}/disable`)
+        toast.success(t('settings.plugins.disabled'))
+      }
+      await fetchPlugins()
+    } catch (err) {
+      toast.error(getErrorMessage(err))
+    }
+  }
+
+  const handleReload = async () => {
+    setReloading(true)
+    try {
+      await api.post('/plugins/reload')
+      await fetchPlugins()
+      toast.success(t('settings.plugins.reloaded'))
+    } catch (err) {
+      toast.error(getErrorMessage(err))
+    } finally {
+      setReloading(false)
+    }
+  }
+
+  const openConfig = async (plugin: PluginSummary) => {
+    try {
+      const config = await api.get<Record<string, any>>(`/plugins/${plugin.name}/config`)
+      setConfigValues(config)
+      setConfigPlugin(plugin)
+    } catch (err) {
+      toast.error(getErrorMessage(err))
+    }
+  }
+
+  const saveConfig = async () => {
+    if (!configPlugin) return
+    setSaving(true)
+    try {
+      await api.put(`/plugins/${configPlugin.name}/config`, configValues)
+      toast.success(t('settings.plugins.configSaved'))
+      setConfigPlugin(null)
+      await fetchPlugins()
+    } catch (err) {
+      toast.error(getErrorMessage(err))
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (isLoading) return <SettingsListSkeleton />
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h3 className="text-lg font-semibold">{t('settings.plugins.title')}</h3>
+          <p className="text-sm text-muted-foreground">{t('settings.plugins.description')}</p>
+        </div>
+        <Button variant="outline" size="sm" onClick={handleReload} disabled={reloading}>
+          <RefreshCw className={`size-4 mr-2 ${reloading ? 'animate-spin' : ''}`} />
+          {t('settings.plugins.reload')}
+        </Button>
+      </div>
+
+      {/* Plugin list */}
+      {plugins.length === 0 ? (
+        <EmptyState
+          icon={Plug}
+          title={t('settings.plugins.empty.title')}
+          description={t('settings.plugins.empty.description')}
+        />
+      ) : (
+        <div className="space-y-3">
+          {plugins.map((plugin) => (
+            <div
+              key={plugin.name}
+              className="rounded-lg border p-4 surface-card"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <h4 className="font-medium">{plugin.name}</h4>
+                    <Badge variant="outline" className="text-xs">
+                      v{plugin.version}
+                    </Badge>
+                    {plugin.error && (
+                      <Badge variant="destructive" className="text-xs">
+                        <AlertTriangle className="size-3 mr-1" />
+                        {t('settings.plugins.error')}
+                      </Badge>
+                    )}
+                  </div>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {plugin.description}
+                  </p>
+                  {plugin.author && (
+                    <p className="text-xs text-muted-foreground/70 mt-1">
+                      {t('settings.plugins.by')} {plugin.author}
+                    </p>
+                  )}
+
+                  {/* Stats */}
+                  <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
+                    {plugin.toolCount > 0 && (
+                      <span className="flex items-center gap-1">
+                        <Wrench className="size-3" />
+                        {plugin.toolCount} {t('settings.plugins.tools')}
+                      </span>
+                    )}
+                    {plugin.hookCount > 0 && (
+                      <span className="flex items-center gap-1">
+                        <Anchor className="size-3" />
+                        {plugin.hookCount} {t('settings.plugins.hooks')}
+                      </span>
+                    )}
+                    {plugin.permissions.length > 0 && (
+                      <span className="flex items-center gap-1">
+                        <Shield className="size-3" />
+                        {plugin.permissions.length} {t('settings.plugins.permissions')}
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Permissions detail */}
+                  {plugin.permissions.length > 0 && (
+                    <Collapsible>
+                      <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground mt-1">
+                        <ChevronDown className="size-3" />
+                        {t('settings.plugins.viewPermissions')}
+                      </CollapsibleTrigger>
+                      <CollapsibleContent className="mt-1">
+                        <div className="flex flex-wrap gap-1">
+                          {plugin.permissions.map((p) => (
+                            <Badge key={p} variant="secondary" className="text-xs font-mono">
+                              {p}
+                            </Badge>
+                          ))}
+                        </div>
+                      </CollapsibleContent>
+                    </Collapsible>
+                  )}
+
+                  {plugin.error && (
+                    <p className="text-xs text-destructive mt-2">{plugin.error}</p>
+                  )}
+                </div>
+
+                {/* Actions */}
+                <div className="flex items-center gap-2 shrink-0">
+                  {Object.keys(plugin.configSchema).length > 0 && (
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => openConfig(plugin)}
+                      title={t('settings.plugins.configure')}
+                    >
+                      <Settings2 className="size-4" />
+                    </Button>
+                  )}
+                  <Switch
+                    checked={plugin.enabled}
+                    onCheckedChange={(checked) => handleToggle(plugin.name, checked)}
+                    disabled={!!plugin.error && !plugin.enabled}
+                  />
+                </div>
+              </div>
+
+              {plugin.homepage && (
+                <a
+                  href={plugin.homepage}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-xs text-primary hover:underline mt-2"
+                >
+                  <ExternalLink className="size-3" />
+                  {t('settings.plugins.homepage')}
+                </a>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Config dialog */}
+      <Dialog open={!!configPlugin} onOpenChange={(open) => !open && setConfigPlugin(null)}>
+        <DialogContent className="sm:max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {t('settings.plugins.configureTitle', { name: configPlugin?.name })}
+            </DialogTitle>
+            <DialogDescription>
+              {t('settings.plugins.configureDescription')}
+            </DialogDescription>
+          </DialogHeader>
+
+          {configPlugin && (
+            <div className="space-y-4 py-2">
+              {Object.entries(configPlugin.configSchema).map(([key, field]) => (
+                <ConfigFieldRenderer
+                  key={key}
+                  fieldKey={key}
+                  field={field}
+                  value={configValues[key] ?? field.default ?? ''}
+                  onChange={(v) => setConfigValues((prev) => ({ ...prev, [key]: v }))}
+                />
+              ))}
+            </div>
+          )}
+
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setConfigPlugin(null)}>
+              {t('common.cancel')}
+            </Button>
+            <Button onClick={saveConfig} disabled={saving}>
+              {saving ? t('common.saving') : t('common.save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}
+
+// ─── Config field renderer ───────────────────────────────────────────────────
+
+function ConfigFieldRenderer({
+  fieldKey,
+  field,
+  value,
+  onChange,
+}: {
+  fieldKey: string
+  field: PluginConfigField
+  value: any
+  onChange: (value: any) => void
+}) {
+  return (
+    <div className="space-y-1.5">
+      <Label htmlFor={fieldKey}>
+        {field.label}
+        {field.required && <span className="text-destructive ml-1">*</span>}
+      </Label>
+      {field.description && (
+        <p className="text-xs text-muted-foreground">{field.description}</p>
+      )}
+
+      {field.type === 'string' && (
+        <Input
+          id={fieldKey}
+          type={field.secret ? 'password' : 'text'}
+          value={value ?? ''}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={field.placeholder}
+        />
+      )}
+
+      {field.type === 'number' && (
+        <Input
+          id={fieldKey}
+          type="number"
+          value={value ?? ''}
+          onChange={(e) => onChange(e.target.value ? Number(e.target.value) : '')}
+          min={field.min}
+          max={field.max}
+          step={field.step}
+        />
+      )}
+
+      {field.type === 'boolean' && (
+        <Switch
+          id={fieldKey}
+          checked={!!value}
+          onCheckedChange={onChange}
+        />
+      )}
+
+      {field.type === 'select' && field.options && (
+        <Select value={String(value ?? '')} onValueChange={onChange}>
+          <SelectTrigger>
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            {field.options.map((opt) => (
+              <SelectItem key={opt} value={opt}>
+                {opt}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      )}
+
+      {field.type === 'text' && (
+        <Textarea
+          id={fieldKey}
+          value={value ?? ''}
+          onChange={(e) => onChange(e.target.value)}
+          rows={field.rows ?? 3}
+          placeholder={field.placeholder}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/client/pages/settings/SettingsPage.tsx
+++ b/src/client/pages/settings/SettingsPage.tsx
@@ -31,6 +31,7 @@ import { WebhooksSettings } from '@/client/pages/settings/WebhooksSettings'
 import { ChannelsSettings } from '@/client/pages/settings/ChannelsSettings'
 import { UsersSettings } from '@/client/pages/settings/UsersSettings'
 import { NotificationPreferences } from '@/client/components/notifications/NotificationPreferences'
+import { PluginsSettings } from '@/client/pages/settings/PluginsSettings'
 import {
   Bell,
   Brain,
@@ -76,6 +77,7 @@ const sectionGroups: SectionGroup[] = [
   {
     groupKey: 'settings.groups.extensions',
     items: [
+      { id: 'plugins', icon: Plug, labelKey: 'settings.plugins.title' },
       { id: 'mcp', icon: Puzzle, labelKey: 'settings.mcp.title' },
       { id: 'vault', icon: Lock, labelKey: 'settings.vault.title' },
       { id: 'memories', icon: Brain, labelKey: 'settings.memories.title' },
@@ -115,6 +117,7 @@ const sectionComponents: Record<string, React.FC> = {
   files: FileStorageSettings,
   webhooks: WebhooksSettings,
   channels: ChannelsSettings,
+  plugins: PluginsSettings,
   notifications: NotificationPreferences,
 }
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -37,6 +37,7 @@ import { invitationRoutes } from '@/server/routes/invitations'
 import { notificationRoutes } from '@/server/routes/notifications'
 import { settingsRoutes } from '@/server/routes/settings'
 import { miniAppRoutes, miniAppSdkRoutes } from '@/server/routes/mini-apps'
+import { pluginRoutes } from '@/server/routes/plugins'
 
 export type AppVariables = {
   session: { id: string; userId: string; token: string }
@@ -169,6 +170,7 @@ app.route('/api/kins/:kinId/quick-sessions', quickSessionKinRoutes)
 app.route('/api/quick-sessions', quickSessionDetailRoutes)
 app.route('/api/mini-apps/sdk', miniAppSdkRoutes)
 app.route('/api/mini-apps', miniAppRoutes)
+app.route('/api/plugins', pluginRoutes)
 app.route('/s', sharedRoutes)
 
 export { app }

--- a/src/server/db/migrations/0033_equal_wonder_man.sql
+++ b/src/server/db/migrations/0033_equal_wonder_man.sql
@@ -1,0 +1,19 @@
+CREATE TABLE `plugin_states` (
+	`name` text PRIMARY KEY NOT NULL,
+	`enabled` integer DEFAULT false NOT NULL,
+	`config_encrypted` text,
+	`approved_permissions` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `plugin_storage` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`plugin_name` text NOT NULL,
+	`key` text NOT NULL,
+	`value` text NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `idx_plugin_storage_name_key` ON `plugin_storage` (`plugin_name`,`key`);--> statement-breakpoint
+CREATE INDEX `idx_plugin_storage_plugin` ON `plugin_storage` (`plugin_name`);

--- a/src/server/db/migrations/meta/0033_snapshot.json
+++ b/src/server/db/migrations/meta/0033_snapshot.json
@@ -1,0 +1,4635 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "cd8e83f9-d4aa-4f5d-8efe-d2b3ef9b6a6a",
+  "prevId": "078f4e63-868c-4e77-9612-91c256e0431e",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_message_links": {
+      "name": "channel_message_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_chat_id": {
+          "name": "platform_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cml_message": {
+          "name": "idx_cml_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_cml_channel": {
+          "name": "idx_cml_channel",
+          "columns": [
+            "channel_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_message_links_channel_id_channels_id_fk": {
+          "name": "channel_message_links_channel_id_channels_id_fk",
+          "tableFrom": "channel_message_links",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_message_links_message_id_messages_id_fk": {
+          "name": "channel_message_links_message_id_messages_id_fk",
+          "tableFrom": "channel_message_links",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_user_mappings": {
+      "name": "channel_user_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_username": {
+          "name": "platform_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform_display_name": {
+          "name": "platform_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'approved'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_channel_user_map": {
+          "name": "idx_channel_user_map",
+          "columns": [
+            "channel_id",
+            "platform_user_id"
+          ],
+          "isUnique": true
+        },
+        "idx_channel_user_map_status": {
+          "name": "idx_channel_user_map_status",
+          "columns": [
+            "channel_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_user_mappings_channel_id_channels_id_fk": {
+          "name": "channel_user_mappings_channel_id_channels_id_fk",
+          "tableFrom": "channel_user_mappings",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_user_mappings_contact_id_contacts_id_fk": {
+          "name": "channel_user_mappings_contact_id_contacts_id_fk",
+          "tableFrom": "channel_user_mappings",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_config": {
+          "name": "platform_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inactive'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_create_contacts": {
+          "name": "auto_create_contacts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "messages_received": {
+          "name": "messages_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "messages_sent": {
+          "name": "messages_sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_channels_kin_id": {
+          "name": "idx_channels_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_kin_id_kins_id_fk": {
+          "name": "channels_kin_id_kins_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "compacting_snapshots": {
+      "name": "compacting_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages_up_to_id": {
+          "name": "messages_up_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_compacting_kin_active": {
+          "name": "idx_compacting_kin_active",
+          "columns": [
+            "kin_id",
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "compacting_snapshots_kin_id_kins_id_fk": {
+          "name": "compacting_snapshots_kin_id_kins_id_fk",
+          "tableFrom": "compacting_snapshots",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "compacting_snapshots_messages_up_to_id_messages_id_fk": {
+          "name": "compacting_snapshots_messages_up_to_id_messages_id_fk",
+          "tableFrom": "compacting_snapshots",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "messages_up_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_identifiers": {
+      "name": "contact_identifiers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_contact_identifiers_contact_id": {
+          "name": "idx_contact_identifiers_contact_id",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_identifiers_contact_id_contacts_id_fk": {
+          "name": "contact_identifiers_contact_id_contacts_id_fk",
+          "tableFrom": "contact_identifiers",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_notes": {
+      "name": "contact_notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_contact_notes_unique": {
+          "name": "idx_contact_notes_unique",
+          "columns": [
+            "contact_id",
+            "kin_id",
+            "scope"
+          ],
+          "isUnique": true
+        },
+        "idx_contact_notes_contact_id": {
+          "name": "idx_contact_notes_contact_id",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        },
+        "idx_contact_notes_kin_id": {
+          "name": "idx_contact_notes_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_notes_contact_id_contacts_id_fk": {
+          "name": "contact_notes_contact_id_contacts_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_notes_kin_id_kins_id_fk": {
+          "name": "contact_notes_kin_id_kins_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_platform_ids": {
+      "name": "contact_platform_ids",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_contact_platform_ids_unique": {
+          "name": "idx_contact_platform_ids_unique",
+          "columns": [
+            "platform",
+            "platform_id"
+          ],
+          "isUnique": true
+        },
+        "idx_contact_platform_ids_contact": {
+          "name": "idx_contact_platform_ids_contact",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_platform_ids_contact_id_contacts_id_fk": {
+          "name": "contact_platform_ids_contact_id_contacts_id_fk",
+          "tableFrom": "contact_platform_ids",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contacts": {
+      "name": "contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_user_id": {
+          "name": "linked_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linked_kin_id": {
+          "name": "linked_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contacts_linked_user_id_user_id_fk": {
+          "name": "contacts_linked_user_id_user_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "linked_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contacts_linked_kin_id_kins_id_fk": {
+          "name": "contacts_linked_kin_id_kins_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "linked_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crons": {
+      "name": "crons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_description": {
+          "name": "task_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kin_id": {
+          "name": "target_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "requires_approval": {
+          "name": "requires_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "run_once": {
+          "name": "run_once",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "crons_kin_id_kins_id_fk": {
+          "name": "crons_kin_id_kins_id_fk",
+          "tableFrom": "crons",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "crons_target_kin_id_kins_id_fk": {
+          "name": "crons_target_kin_id_kins_id_fk",
+          "tableFrom": "crons",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "target_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_tools": {
+      "name": "custom_tools",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "script_path": {
+          "name": "script_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_tools_kin_name": {
+          "name": "idx_custom_tools_kin_name",
+          "columns": [
+            "kin_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "custom_tools_kin_id_kins_id_fk": {
+          "name": "custom_tools_kin_id_kins_id_fk",
+          "tableFrom": "custom_tools",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_storage": {
+      "name": "file_storage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stored_path": {
+          "name": "stored_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "read_and_burn": {
+          "name": "read_and_burn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_by_kin_id": {
+          "name": "created_by_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "file_storage_access_token_unique": {
+          "name": "file_storage_access_token_unique",
+          "columns": [
+            "access_token"
+          ],
+          "isUnique": true
+        },
+        "idx_file_storage_token": {
+          "name": "idx_file_storage_token",
+          "columns": [
+            "access_token"
+          ],
+          "isUnique": false
+        },
+        "idx_file_storage_kin": {
+          "name": "idx_file_storage_kin",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        },
+        "idx_file_storage_expires": {
+          "name": "idx_file_storage_expires",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "file_storage_kin_id_kins_id_fk": {
+          "name": "file_storage_kin_id_kins_id_fk",
+          "tableFrom": "file_storage",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "file_storage_created_by_kin_id_kins_id_fk": {
+          "name": "file_storage_created_by_kin_id_kins_id_fk",
+          "tableFrom": "file_storage",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "created_by_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stored_path": {
+          "name": "stored_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "files_kin_id_kins_id_fk": {
+          "name": "files_kin_id_kins_id_fk",
+          "tableFrom": "files",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_message_id_messages_id_fk": {
+          "name": "files_message_id_messages_id_fk",
+          "tableFrom": "files",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_user_id_fk": {
+          "name": "files_uploaded_by_user_id_fk",
+          "tableFrom": "files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "human_prompts": {
+      "name": "human_prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_type": {
+          "name": "prompt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_human_prompts_kin": {
+          "name": "idx_human_prompts_kin",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        },
+        "idx_human_prompts_task": {
+          "name": "idx_human_prompts_task",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "idx_human_prompts_status": {
+          "name": "idx_human_prompts_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "human_prompts_kin_id_kins_id_fk": {
+          "name": "human_prompts_kin_id_kins_id_fk",
+          "tableFrom": "human_prompts",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "human_prompts_task_id_tasks_id_fk": {
+          "name": "human_prompts_task_id_tasks_id_fk",
+          "tableFrom": "human_prompts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "human_prompts_message_id_messages_id_fk": {
+          "name": "human_prompts_message_id_messages_id_fk",
+          "tableFrom": "human_prompts",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitations": {
+      "name": "invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_invitations_created_by": {
+          "name": "idx_invitations_created_by",
+          "columns": [
+            "created_by"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitations_created_by_user_id_fk": {
+          "name": "invitations_created_by_user_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_kin_id_kins_id_fk": {
+          "name": "invitations_kin_id_kins_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitations_used_by_user_id_fk": {
+          "name": "invitations_used_by_user_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kin_mcp_servers": {
+      "name": "kin_mcp_servers",
+      "columns": {
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kin_mcp_servers_kin_id_kins_id_fk": {
+          "name": "kin_mcp_servers_kin_id_kins_id_fk",
+          "tableFrom": "kin_mcp_servers",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kin_mcp_servers_mcp_server_id_mcp_servers_id_fk": {
+          "name": "kin_mcp_servers_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "kin_mcp_servers",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "kin_mcp_servers_kin_id_mcp_server_id_pk": {
+          "columns": [
+            "kin_id",
+            "mcp_server_id"
+          ],
+          "name": "kin_mcp_servers_kin_id_mcp_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kins": {
+      "name": "kins",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "character": {
+          "name": "character",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expertise": {
+          "name": "expertise",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_config": {
+          "name": "tool_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "kins_slug_unique": {
+          "name": "kins_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "kins_provider_id_providers_id_fk": {
+          "name": "kins_provider_id_providers_id_fk",
+          "tableFrom": "kins",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kins_created_by_user_id_fk": {
+          "name": "kins_created_by_user_id_fk",
+          "tableFrom": "kins",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_kin_id": {
+          "name": "created_by_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_servers_created_by_kin_id_kins_id_fk": {
+          "name": "mcp_servers_created_by_kin_id_kins_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "created_by_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_channel": {
+          "name": "source_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'automatic'"
+        },
+        "importance": {
+          "name": "importance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieval_count": {
+          "name": "retrieval_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_retrieved_at": {
+          "name": "last_retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consolidation_generation": {
+          "name": "consolidation_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "consolidated_from_ids": {
+          "name": "consolidated_from_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_memories_kin_id": {
+          "name": "idx_memories_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        },
+        "idx_memories_kin_category": {
+          "name": "idx_memories_kin_category",
+          "columns": [
+            "kin_id",
+            "category"
+          ],
+          "isUnique": false
+        },
+        "idx_memories_kin_subject": {
+          "name": "idx_memories_kin_subject",
+          "columns": [
+            "kin_id",
+            "subject"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memories_kin_id_kins_id_fk": {
+          "name": "memories_kin_id_kins_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "memories_source_message_id_messages_id_fk": {
+          "name": "memories_source_message_id_messages_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "source_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_reactions": {
+      "name": "message_reactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_message_reactions_unique": {
+          "name": "idx_message_reactions_unique",
+          "columns": [
+            "message_id",
+            "user_id",
+            "emoji"
+          ],
+          "isUnique": true
+        },
+        "idx_message_reactions_message": {
+          "name": "idx_message_reactions_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_reactions_message_id_messages_id_fk": {
+          "name": "message_reactions_message_id_messages_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_reactions_user_id_user_id_fk": {
+          "name": "message_reactions_user_id_user_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_redacted": {
+          "name": "is_redacted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "redact_pending": {
+          "name": "redact_pending",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_messages_kin_id": {
+          "name": "idx_messages_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_task_id": {
+          "name": "idx_messages_task_id",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_kin_created": {
+          "name": "idx_messages_kin_created",
+          "columns": [
+            "kin_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_source": {
+          "name": "idx_messages_source",
+          "columns": [
+            "source_type",
+            "source_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_session_id": {
+          "name": "idx_messages_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_kin_id_kins_id_fk": {
+          "name": "messages_kin_id_kins_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messages_session_id_quick_sessions_id_fk": {
+          "name": "messages_session_id_quick_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "quick_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mini_app_snapshots": {
+      "name": "mini_app_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_manifest": {
+          "name": "file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mini_app_snapshots_app_id": {
+          "name": "idx_mini_app_snapshots_app_id",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        },
+        "idx_mini_app_snapshots_app_version": {
+          "name": "idx_mini_app_snapshots_app_version",
+          "columns": [
+            "app_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mini_app_snapshots_app_id_mini_apps_id_fk": {
+          "name": "mini_app_snapshots_app_id_mini_apps_id_fk",
+          "tableFrom": "mini_app_snapshots",
+          "tableTo": "mini_apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mini_app_storage": {
+      "name": "mini_app_storage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mini_app_storage_app_key": {
+          "name": "idx_mini_app_storage_app_key",
+          "columns": [
+            "app_id",
+            "key"
+          ],
+          "isUnique": true
+        },
+        "idx_mini_app_storage_app_id": {
+          "name": "idx_mini_app_storage_app_id",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mini_app_storage_app_id_mini_apps_id_fk": {
+          "name": "mini_app_storage_app_id_mini_apps_id_fk",
+          "tableFrom": "mini_app_storage",
+          "tableTo": "mini_apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mini_apps": {
+      "name": "mini_apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_file": {
+          "name": "entry_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'index.html'"
+        },
+        "has_backend": {
+          "name": "has_backend",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mini_apps_kin_slug": {
+          "name": "idx_mini_apps_kin_slug",
+          "columns": [
+            "kin_id",
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_mini_apps_kin_id": {
+          "name": "idx_mini_apps_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mini_apps_kin_id_kins_id_fk": {
+          "name": "mini_apps_kin_id_kins_id_fk",
+          "tableFrom": "mini_apps",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_channels": {
+      "name": "notification_channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_chat_id": {
+          "name": "platform_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "type_filter": {
+          "name": "type_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_delivered_at": {
+          "name": "last_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consecutive_errors": {
+          "name": "consecutive_errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notif_channels_user": {
+          "name": "idx_notif_channels_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_notif_channels_unique": {
+          "name": "idx_notif_channels_unique",
+          "columns": [
+            "user_id",
+            "channel_id",
+            "platform_chat_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "notification_channels_user_id_user_id_fk": {
+          "name": "notification_channels_user_id_user_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_channels_channel_id_channels_id_fk": {
+          "name": "notification_channels_channel_id_channels_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_preferences": {
+      "name": "notification_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_notif_pref_user_type": {
+          "name": "idx_notif_pref_user_type",
+          "columns": [
+            "user_id",
+            "type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "notification_preferences_user_id_user_id_fk": {
+          "name": "notification_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_id": {
+          "name": "related_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_type": {
+          "name": "related_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_read": {
+          "name": "idx_notifications_user_read",
+          "columns": [
+            "user_id",
+            "is_read",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_notifications_user_created": {
+          "name": "idx_notifications_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_kin_id_kins_id_fk": {
+          "name": "notifications_kin_id_kins_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_states": {
+      "name": "plugin_states",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_permissions": {
+          "name": "approved_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_storage": {
+      "name": "plugin_storage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "plugin_name": {
+          "name": "plugin_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_plugin_storage_name_key": {
+          "name": "idx_plugin_storage_name_key",
+          "columns": [
+            "plugin_name",
+            "key"
+          ],
+          "isUnique": true
+        },
+        "idx_plugin_storage_plugin": {
+          "name": "idx_plugin_storage_plugin",
+          "columns": [
+            "plugin_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers": {
+      "name": "providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queue_items": {
+      "name": "queue_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_queue_kin_status_priority": {
+          "name": "idx_queue_kin_status_priority",
+          "columns": [
+            "kin_id",
+            "status",
+            "priority",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "queue_items_kin_id_kins_id_fk": {
+          "name": "queue_items_kin_id_kins_id_fk",
+          "tableFrom": "queue_items",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "queue_items_task_id_tasks_id_fk": {
+          "name": "queue_items_task_id_tasks_id_fk",
+          "tableFrom": "queue_items",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quick_sessions": {
+      "name": "quick_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_quick_sessions_kin_status": {
+          "name": "idx_quick_sessions_kin_status",
+          "columns": [
+            "kin_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_quick_sessions_user": {
+          "name": "idx_quick_sessions_user",
+          "columns": [
+            "created_by"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "quick_sessions_kin_id_kins_id_fk": {
+          "name": "quick_sessions_kin_id_kins_id_fk",
+          "tableFrom": "quick_sessions",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quick_sessions_created_by_user_id_fk": {
+          "name": "quick_sessions_created_by_user_id_fk",
+          "tableFrom": "quick_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_wakeups": {
+      "name": "scheduled_wakeups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_kin_id": {
+          "name": "caller_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kin_id": {
+          "name": "target_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_at": {
+          "name": "fire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wakeups_target_status": {
+          "name": "idx_wakeups_target_status",
+          "columns": [
+            "target_kin_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_wakeups_caller": {
+          "name": "idx_wakeups_caller",
+          "columns": [
+            "caller_kin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_wakeups_caller_kin_id_kins_id_fk": {
+          "name": "scheduled_wakeups_caller_kin_id_kins_id_fk",
+          "tableFrom": "scheduled_wakeups",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "caller_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_wakeups_target_kin_id_kins_id_fk": {
+          "name": "scheduled_wakeups_target_kin_id_kins_id_fk",
+          "tableFrom": "scheduled_wakeups",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "target_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_kin_id": {
+          "name": "parent_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kin_id": {
+          "name": "source_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spawn_type": {
+          "name": "spawn_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'await'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "parent_task_id": {
+          "name": "parent_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cron_id": {
+          "name": "cron_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_input_count": {
+          "name": "request_input_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "allow_human_prompt": {
+          "name": "allow_human_prompt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tasks_parent_kin": {
+          "name": "idx_tasks_parent_kin",
+          "columns": [
+            "parent_kin_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tasks_status": {
+          "name": "idx_tasks_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_tasks_cron": {
+          "name": "idx_tasks_cron",
+          "columns": [
+            "cron_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_parent_kin_id_kins_id_fk": {
+          "name": "tasks_parent_kin_id_kins_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "parent_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_source_kin_id_kins_id_fk": {
+          "name": "tasks_source_kin_id_kins_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "source_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_parent_task_id_tasks_id_fk": {
+          "name": "tasks_parent_task_id_tasks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "parent_task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_cron_id_crons_id_fk": {
+          "name": "tasks_cron_id_crons_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "crons",
+          "columnsFrom": [
+            "cron_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profiles": {
+      "name": "user_profiles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pseudonym": {
+          "name": "pseudonym",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'fr'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "kin_order": {
+          "name": "kin_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cron_order": {
+          "name": "cron_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_user_id_fk": {
+          "name": "user_profiles_user_id_user_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_attachments": {
+      "name": "vault_attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stored_path": {
+          "name": "stored_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_vault_attachments_entry": {
+          "name": "idx_vault_attachments_entry",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "vault_attachments_entry_id_vault_secrets_id_fk": {
+          "name": "vault_attachments_entry_id_vault_secrets_id_fk",
+          "tableFrom": "vault_attachments",
+          "tableTo": "vault_secrets",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_secrets": {
+      "name": "vault_secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "vault_type_id": {
+          "name": "vault_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by_kin_id": {
+          "name": "created_by_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "vault_secrets_key_unique": {
+          "name": "vault_secrets_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "idx_vault_secrets_entry_type": {
+          "name": "idx_vault_secrets_entry_type",
+          "columns": [
+            "entry_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "vault_secrets_vault_type_id_vault_types_id_fk": {
+          "name": "vault_secrets_vault_type_id_vault_types_id_fk",
+          "tableFrom": "vault_secrets",
+          "tableTo": "vault_types",
+          "columnsFrom": [
+            "vault_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vault_secrets_created_by_kin_id_kins_id_fk": {
+          "name": "vault_secrets_created_by_kin_id_kins_id_fk",
+          "tableFrom": "vault_secrets",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "created_by_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_types": {
+      "name": "vault_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_built_in": {
+          "name": "is_built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by_kin_id": {
+          "name": "created_by_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "vault_types_slug_unique": {
+          "name": "vault_types_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "vault_types_created_by_kin_id_kins_id_fk": {
+          "name": "vault_types_created_by_kin_id_kins_id_fk",
+          "tableFrom": "vault_types",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "created_by_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_logs": {
+      "name": "webhook_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webhook_logs_webhook_created": {
+          "name": "idx_webhook_logs_webhook_created",
+          "columns": [
+            "webhook_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_logs_webhook_id_webhooks_id_fk": {
+          "name": "webhook_logs_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_logs",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_count": {
+          "name": "trigger_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhooks_token_unique": {
+          "name": "webhooks_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_webhooks_kin_id": {
+          "name": "idx_webhooks_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhooks_kin_id_kins_id_fk": {
+          "name": "webhooks_kin_id_kins_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/server/db/migrations/meta/_journal.json
+++ b/src/server/db/migrations/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1772565046070,
       "tag": "0032_breezy_captain_cross",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "6",
+      "when": 1772628164083,
+      "tag": "0033_equal_wonder_man",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -614,3 +614,25 @@ export const fileStorage = sqliteTable('file_storage', {
   index('idx_file_storage_kin').on(table.kinId),
   index('idx_file_storage_expires').on(table.expiresAt),
 ])
+
+// ─── Plugin System ───────────────────────────────────────────────────────────
+
+export const pluginStates = sqliteTable('plugin_states', {
+  name: text('name').primaryKey(),
+  enabled: integer('enabled', { mode: 'boolean' }).notNull().default(false),
+  configEncrypted: text('config_encrypted'), // JSON, secrets encrypted
+  approvedPermissions: text('approved_permissions'), // JSON array
+  createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
+  updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
+})
+
+export const pluginStorage = sqliteTable('plugin_storage', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  pluginName: text('plugin_name').notNull(),
+  key: text('key').notNull(),
+  value: text('value').notNull(), // JSON-encoded
+  updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),
+}, (table) => [
+  uniqueIndex('idx_plugin_storage_name_key').on(table.pluginName, table.key),
+  index('idx_plugin_storage_plugin').on(table.pluginName),
+])

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -21,6 +21,7 @@ import { SignalAdapter } from '@/server/channels/signal'
 import { MatrixAdapter } from '@/server/channels/matrix'
 import { restoreActiveChannels } from '@/server/services/channels'
 import { ensureUserContactsExist } from '@/server/services/contacts'
+import { pluginManager } from '@/server/services/plugins'
 
 const log = createLogger('server')
 
@@ -37,6 +38,10 @@ log.info('Virtual tables initialized')
 // Register native tools
 log.info('Registering native tools...')
 registerAllTools()
+
+// Scan and load plugins
+log.info('Scanning for plugins...')
+await pluginManager.scan()
 
 // Start the queue worker
 log.info('Starting queue worker...')

--- a/src/server/routes/plugins.ts
+++ b/src/server/routes/plugins.ts
@@ -1,0 +1,73 @@
+import { Hono } from 'hono'
+import { pluginManager } from '@/server/services/plugins'
+import type { AppVariables } from '@/server/app'
+import { createLogger } from '@/server/logger'
+
+const log = createLogger('routes:plugins')
+
+export const pluginRoutes = new Hono<{ Variables: AppVariables }>()
+
+// GET /api/plugins — list all plugins
+pluginRoutes.get('/', async (c) => {
+  const plugins = pluginManager.listPlugins()
+  return c.json(plugins)
+})
+
+// POST /api/plugins/:name/enable
+pluginRoutes.post('/:name/enable', async (c) => {
+  const { name } = c.req.param()
+  try {
+    await pluginManager.enablePlugin(name)
+    return c.json({ success: true })
+  } catch (err) {
+    log.error({ plugin: name, err }, 'Failed to enable plugin')
+    return c.json({ error: { code: 'PLUGIN_ENABLE_FAILED', message: err instanceof Error ? err.message : 'Failed to enable plugin' } }, 400)
+  }
+})
+
+// POST /api/plugins/:name/disable
+pluginRoutes.post('/:name/disable', async (c) => {
+  const { name } = c.req.param()
+  try {
+    await pluginManager.disablePlugin(name)
+    return c.json({ success: true })
+  } catch (err) {
+    log.error({ plugin: name, err }, 'Failed to disable plugin')
+    return c.json({ error: { code: 'PLUGIN_DISABLE_FAILED', message: err instanceof Error ? err.message : 'Failed to disable plugin' } }, 400)
+  }
+})
+
+// GET /api/plugins/:name/config
+pluginRoutes.get('/:name/config', async (c) => {
+  const { name } = c.req.param()
+  try {
+    const config = await pluginManager.getConfigForAPI(name)
+    return c.json(config)
+  } catch (err) {
+    return c.json({ error: { code: 'PLUGIN_NOT_FOUND', message: 'Plugin not found' } }, 404)
+  }
+})
+
+// PUT /api/plugins/:name/config
+pluginRoutes.put('/:name/config', async (c) => {
+  const { name } = c.req.param()
+  try {
+    const body = await c.req.json()
+    await pluginManager.setConfig(name, body)
+    return c.json({ success: true })
+  } catch (err) {
+    log.error({ plugin: name, err }, 'Failed to update plugin config')
+    return c.json({ error: { code: 'PLUGIN_CONFIG_FAILED', message: err instanceof Error ? err.message : 'Failed to update config' } }, 400)
+  }
+})
+
+// POST /api/plugins/reload
+pluginRoutes.post('/reload', async (c) => {
+  try {
+    await pluginManager.reload()
+    return c.json({ success: true, plugins: pluginManager.listPlugins() })
+  } catch (err) {
+    log.error({ err }, 'Failed to reload plugins')
+    return c.json({ error: { code: 'PLUGIN_RELOAD_FAILED', message: 'Failed to reload plugins' } }, 500)
+  }
+})

--- a/src/server/services/plugins.test.ts
+++ b/src/server/services/plugins.test.ts
@@ -1,0 +1,191 @@
+import { describe, test, expect } from 'bun:test'
+import { validateManifest } from '@/server/services/plugins'
+
+describe('validateManifest', () => {
+  test('accepts a valid minimal manifest', () => {
+    const result = validateManifest({
+      name: 'my-plugin',
+      version: '1.0.0',
+      description: 'A test plugin',
+      main: 'index.ts',
+    })
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
+  })
+
+  test('accepts a full manifest with config', () => {
+    const result = validateManifest({
+      name: 'weather',
+      version: '2.0.0',
+      description: 'Weather plugin',
+      author: 'Test',
+      homepage: 'https://example.com',
+      license: 'MIT',
+      kinbot: '>=0.10.0',
+      main: 'index.ts',
+      icon: 'icon.png',
+      permissions: ['http:api.example.com', 'storage'],
+      config: {
+        apiKey: {
+          type: 'string',
+          label: 'API Key',
+          required: true,
+          secret: true,
+        },
+        units: {
+          type: 'select',
+          label: 'Units',
+          options: ['metric', 'imperial'],
+          default: 'metric',
+        },
+        enabled: {
+          type: 'boolean',
+          label: 'Enabled',
+        },
+        count: {
+          type: 'number',
+          label: 'Count',
+          min: 0,
+          max: 100,
+        },
+        notes: {
+          type: 'text',
+          label: 'Notes',
+          rows: 5,
+        },
+      },
+    })
+    expect(result.valid).toBe(true)
+    expect(result.errors).toHaveLength(0)
+  })
+
+  test('rejects null input', () => {
+    const result = validateManifest(null)
+    expect(result.valid).toBe(false)
+    expect(result.errors).toContain('Manifest must be a JSON object')
+  })
+
+  test('rejects missing name', () => {
+    const result = validateManifest({
+      version: '1.0.0',
+      description: 'Test',
+      main: 'index.ts',
+    })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('name'))).toBe(true)
+  })
+
+  test('rejects invalid name format', () => {
+    const result = validateManifest({
+      name: 'My Plugin!',
+      version: '1.0.0',
+      description: 'Test',
+      main: 'index.ts',
+    })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('name'))).toBe(true)
+  })
+
+  test('rejects missing version', () => {
+    const result = validateManifest({
+      name: 'test',
+      description: 'Test',
+      main: 'index.ts',
+    })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('version'))).toBe(true)
+  })
+
+  test('rejects missing description', () => {
+    const result = validateManifest({
+      name: 'test',
+      version: '1.0.0',
+      main: 'index.ts',
+    })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('description'))).toBe(true)
+  })
+
+  test('rejects missing main', () => {
+    const result = validateManifest({
+      name: 'test',
+      version: '1.0.0',
+      description: 'Test',
+    })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('main'))).toBe(true)
+  })
+
+  test('rejects invalid config field type', () => {
+    const result = validateManifest({
+      name: 'test',
+      version: '1.0.0',
+      description: 'Test',
+      main: 'index.ts',
+      config: {
+        field: {
+          type: 'invalid',
+          label: 'Field',
+        },
+      },
+    })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('type'))).toBe(true)
+  })
+
+  test('rejects select without options', () => {
+    const result = validateManifest({
+      name: 'test',
+      version: '1.0.0',
+      description: 'Test',
+      main: 'index.ts',
+      config: {
+        field: {
+          type: 'select',
+          label: 'Field',
+        },
+      },
+    })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('options'))).toBe(true)
+  })
+
+  test('rejects config field without label', () => {
+    const result = validateManifest({
+      name: 'test',
+      version: '1.0.0',
+      description: 'Test',
+      main: 'index.ts',
+      config: {
+        field: {
+          type: 'string',
+        },
+      },
+    })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('label'))).toBe(true)
+  })
+
+  test('rejects non-array permissions', () => {
+    const result = validateManifest({
+      name: 'test',
+      version: '1.0.0',
+      description: 'Test',
+      main: 'index.ts',
+      permissions: 'http:example.com',
+    })
+    expect(result.valid).toBe(false)
+    expect(result.errors.some(e => e.includes('permissions'))).toBe(true)
+  })
+
+  test('collects multiple errors', () => {
+    const result = validateManifest({
+      name: 'INVALID NAME!',
+      version: '',
+      description: '',
+      main: '',
+    })
+    expect(result.valid).toBe(false)
+    expect(result.errors.length).toBeGreaterThan(1)
+  })
+})

--- a/src/server/services/plugins.ts
+++ b/src/server/services/plugins.ts
@@ -1,0 +1,574 @@
+import { resolve, join } from 'path'
+import { readdir, readFile, access } from 'fs/promises'
+import { eq, and, like } from 'drizzle-orm'
+import { db } from '@/server/db/index'
+import { pluginStates, pluginStorage } from '@/server/db/schema'
+import { encrypt, decrypt } from '@/server/services/encryption'
+import { createLogger } from '@/server/logger'
+import { toolRegistry } from '@/server/tools/index'
+import { hookRegistry } from '@/server/hooks/index'
+import type { ToolRegistration } from '@/server/tools/types'
+import type { HookName, HookHandler } from '@/server/hooks/types'
+import type { PluginManifest, PluginConfigField, PluginSummary } from '@/shared/types/plugin'
+
+const log = createLogger('plugins')
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+interface PluginLogger {
+  debug(msg: string): void
+  debug(obj: Record<string, any>, msg: string): void
+  info(msg: string): void
+  info(obj: Record<string, any>, msg: string): void
+  warn(msg: string): void
+  warn(obj: Record<string, any>, msg: string): void
+  error(msg: string): void
+  error(obj: Record<string, any>, msg: string): void
+}
+
+interface PluginStorageAPI {
+  get<T = unknown>(key: string): Promise<T | null>
+  set<T = unknown>(key: string, value: T): Promise<void>
+  delete(key: string): Promise<void>
+  list(prefix?: string): Promise<string[]>
+  clear(): Promise<void>
+}
+
+interface PluginHTTPClient {
+  fetch(url: string, init?: RequestInit): Promise<Response>
+}
+
+interface PluginContext {
+  config: Record<string, any>
+  log: PluginLogger
+  storage: PluginStorageAPI
+  http: PluginHTTPClient
+  manifest: PluginManifest
+}
+
+interface PluginExports {
+  tools?: Record<string, ToolRegistration>
+  hooks?: Partial<Record<HookName, HookHandler>>
+  activate?(): Promise<void>
+  deactivate?(): Promise<void>
+}
+
+interface LoadedPlugin {
+  manifest: PluginManifest
+  exports: PluginExports | null
+  error?: string
+  enabled: boolean
+  registeredTools: string[]
+  registeredHooks: Array<{ name: HookName; handler: HookHandler }>
+}
+
+// ─── Manifest validation ─────────────────────────────────────────────────────
+
+const NAME_PATTERN = /^[a-z0-9-]+$/
+
+export function validateManifest(data: unknown): { valid: boolean; errors: string[] } {
+  const errors: string[] = []
+  if (!data || typeof data !== 'object') {
+    return { valid: false, errors: ['Manifest must be a JSON object'] }
+  }
+
+  const m = data as Record<string, unknown>
+
+  if (typeof m.name !== 'string' || !NAME_PATTERN.test(m.name)) {
+    errors.push('name must match [a-z0-9-]+')
+  }
+  if (typeof m.version !== 'string' || !m.version) {
+    errors.push('version is required')
+  }
+  if (typeof m.description !== 'string' || !m.description) {
+    errors.push('description is required')
+  }
+  if (typeof m.main !== 'string' || !m.main) {
+    errors.push('main entry point is required')
+  }
+
+  // Validate config schema if present
+  if (m.config !== undefined) {
+    if (typeof m.config !== 'object' || m.config === null) {
+      errors.push('config must be an object')
+    } else {
+      const cfg = m.config as Record<string, unknown>
+      for (const [key, field] of Object.entries(cfg)) {
+        if (!field || typeof field !== 'object') {
+          errors.push(`config.${key} must be an object`)
+          continue
+        }
+        const f = field as Record<string, unknown>
+        const validTypes = ['string', 'number', 'boolean', 'select', 'text']
+        if (!validTypes.includes(f.type as string)) {
+          errors.push(`config.${key}.type must be one of: ${validTypes.join(', ')}`)
+        }
+        if (typeof f.label !== 'string') {
+          errors.push(`config.${key}.label is required`)
+        }
+        if (f.type === 'select' && (!Array.isArray(f.options) || f.options.length === 0)) {
+          errors.push(`config.${key} with type "select" requires non-empty options array`)
+        }
+      }
+    }
+  }
+
+  // Validate permissions
+  if (m.permissions !== undefined) {
+    if (!Array.isArray(m.permissions)) {
+      errors.push('permissions must be an array of strings')
+    } else {
+      for (const p of m.permissions) {
+        if (typeof p !== 'string') {
+          errors.push('Each permission must be a string')
+        }
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors }
+}
+
+// ─── Plugin Manager ──────────────────────────────────────────────────────────
+
+class PluginManager {
+  private plugins = new Map<string, LoadedPlugin>()
+  private pluginsDir: string
+
+  constructor() {
+    this.pluginsDir = resolve(process.cwd(), 'plugins')
+  }
+
+  /** Scan plugins/ directory and load all valid plugins */
+  async scan(): Promise<void> {
+    log.info({ dir: this.pluginsDir }, 'Scanning for plugins')
+
+    let entries: string[] = []
+    try {
+      entries = await readdir(this.pluginsDir)
+    } catch {
+      log.info('No plugins/ directory found — skipping plugin scan')
+      return
+    }
+
+    for (const entry of entries.sort()) {
+      const pluginDir = join(this.pluginsDir, entry)
+      const manifestPath = join(pluginDir, 'plugin.json')
+
+      try {
+        await access(manifestPath)
+      } catch {
+        continue // Not a plugin directory
+      }
+
+      try {
+        const raw = await readFile(manifestPath, 'utf-8')
+        const data = JSON.parse(raw)
+        const validation = validateManifest(data)
+
+        if (!validation.valid) {
+          log.warn({ plugin: entry, errors: validation.errors }, 'Invalid plugin manifest')
+          this.plugins.set(entry, {
+            manifest: data as PluginManifest,
+            exports: null,
+            error: `Invalid manifest: ${validation.errors.join('; ')}`,
+            enabled: false,
+            registeredTools: [],
+            registeredHooks: [],
+          })
+          continue
+        }
+
+        const manifest = data as PluginManifest
+
+        // Check for name collision with core tools
+        if (manifest.name !== entry) {
+          log.warn({ folder: entry, name: manifest.name }, 'Plugin folder name does not match manifest name')
+        }
+
+        // Get stored state
+        const state = await this.getState(manifest.name)
+
+        this.plugins.set(manifest.name, {
+          manifest,
+          exports: null,
+          enabled: state?.enabled ?? false,
+          registeredTools: [],
+          registeredHooks: [],
+        })
+
+        log.info({ plugin: manifest.name, version: manifest.version, enabled: state?.enabled ?? false }, 'Plugin discovered')
+
+        // If enabled, activate it
+        if (state?.enabled) {
+          await this.activatePlugin(manifest.name)
+        }
+      } catch (err) {
+        log.error({ plugin: entry, err }, 'Failed to load plugin')
+        this.plugins.set(entry, {
+          manifest: { name: entry, version: '0.0.0', description: 'Failed to load', main: '' } as PluginManifest,
+          exports: null,
+          error: err instanceof Error ? err.message : 'Unknown error',
+          enabled: false,
+          registeredTools: [],
+          registeredHooks: [],
+        })
+      }
+    }
+
+    log.info({ total: this.plugins.size, enabled: Array.from(this.plugins.values()).filter(p => p.enabled).length }, 'Plugin scan complete')
+  }
+
+  /** Activate a plugin: load entry point, register tools/hooks */
+  private async activatePlugin(name: string): Promise<void> {
+    const plugin = this.plugins.get(name)
+    if (!plugin) throw new Error(`Plugin "${name}" not found`)
+
+    const pluginDir = join(this.pluginsDir, name)
+    const entryPath = join(pluginDir, plugin.manifest.main)
+
+    try {
+      // Build context
+      const config = await this.getResolvedConfig(name)
+      const ctx = this.createContext(plugin.manifest, config)
+
+      // Load entry point
+      const mod = await import(entryPath)
+      const initFn = mod.default || mod
+      if (typeof initFn !== 'function') {
+        throw new Error(`Plugin "${name}" main file must default-export a function`)
+      }
+
+      const exports: PluginExports = initFn(ctx)
+      plugin.exports = exports
+
+      // Register tools
+      if (exports.tools) {
+        for (const [toolName, toolReg] of Object.entries(exports.tools)) {
+          const prefixedName = `plugin_${name}_${toolName}`
+
+          // Check for collision with core tools
+          const existingTools = toolRegistry.list().map(t => t.name)
+          if (existingTools.includes(prefixedName)) {
+            log.warn({ plugin: name, tool: toolName }, 'Plugin tool name conflicts — skipping')
+            continue
+          }
+
+          // Plugin tools are always opt-in (defaultDisabled)
+          toolRegistry.register(prefixedName, {
+            ...toolReg,
+            defaultDisabled: true,
+          })
+          plugin.registeredTools.push(prefixedName)
+        }
+      }
+
+      // Register hooks
+      if (exports.hooks) {
+        for (const [hookName, handler] of Object.entries(exports.hooks)) {
+          if (handler) {
+            const wrappedHandler: HookHandler = async (ctx) => {
+              try {
+                return await handler(ctx)
+              } catch (err) {
+                log.error({ plugin: name, hook: hookName, err }, 'Plugin hook error')
+                return ctx
+              }
+            }
+            hookRegistry.register(hookName as HookName, wrappedHandler)
+            plugin.registeredHooks.push({ name: hookName as HookName, handler: wrappedHandler })
+          }
+        }
+      }
+
+      // Call activate
+      if (exports.activate) {
+        await exports.activate()
+      }
+
+      plugin.enabled = true
+      plugin.error = undefined
+      log.info({ plugin: name, tools: plugin.registeredTools.length, hooks: plugin.registeredHooks.length }, 'Plugin activated')
+    } catch (err) {
+      plugin.error = err instanceof Error ? err.message : 'Activation failed'
+      plugin.enabled = false
+      log.error({ plugin: name, err }, 'Plugin activation failed')
+    }
+  }
+
+  /** Deactivate a plugin: unregister tools/hooks, call deactivate */
+  private async deactivatePlugin(name: string): Promise<void> {
+    const plugin = this.plugins.get(name)
+    if (!plugin) return
+
+    // Call deactivate
+    if (plugin.exports?.deactivate) {
+      try {
+        await plugin.exports.deactivate()
+      } catch (err) {
+        log.error({ plugin: name, err }, 'Plugin deactivate() error')
+      }
+    }
+
+    // Unregister hooks
+    for (const { name: hookName, handler } of plugin.registeredHooks) {
+      hookRegistry.unregister(hookName, handler)
+    }
+    plugin.registeredHooks = []
+
+    // Note: toolRegistry doesn't support unregister yet, but tools from disabled plugins
+    // won't be resolved because they're defaultDisabled and not in enabledOptInTools
+    plugin.registeredTools = []
+
+    plugin.exports = null
+    plugin.enabled = false
+    log.info({ plugin: name }, 'Plugin deactivated')
+  }
+
+  /** Create a PluginContext for a plugin */
+  private createContext(manifest: PluginManifest, config: Record<string, any>): PluginContext {
+    const pluginLog = createLogger(`plugin:${manifest.name}`)
+
+    const storage: PluginStorageAPI = {
+      async get<T = unknown>(key: string): Promise<T | null> {
+        const row = await db
+          .select()
+          .from(pluginStorage)
+          .where(and(eq(pluginStorage.pluginName, manifest.name), eq(pluginStorage.key, key)))
+          .get()
+        if (!row) return null
+        return JSON.parse(row.value) as T
+      },
+      async set<T = unknown>(key: string, value: T): Promise<void> {
+        const now = new Date()
+        const jsonValue = JSON.stringify(value)
+        const existing = await db
+          .select()
+          .from(pluginStorage)
+          .where(and(eq(pluginStorage.pluginName, manifest.name), eq(pluginStorage.key, key)))
+          .get()
+        if (existing) {
+          await db
+            .update(pluginStorage)
+            .set({ value: jsonValue, updatedAt: now })
+            .where(eq(pluginStorage.id, existing.id))
+        } else {
+          await db.insert(pluginStorage).values({
+            pluginName: manifest.name,
+            key,
+            value: jsonValue,
+            updatedAt: now,
+          })
+        }
+      },
+      async delete(key: string): Promise<void> {
+        await db
+          .delete(pluginStorage)
+          .where(and(eq(pluginStorage.pluginName, manifest.name), eq(pluginStorage.key, key)))
+      },
+      async list(prefix?: string): Promise<string[]> {
+        const rows = prefix
+          ? await db.select({ key: pluginStorage.key }).from(pluginStorage)
+              .where(and(eq(pluginStorage.pluginName, manifest.name), like(pluginStorage.key, `${prefix}%`)))
+              .all()
+          : await db.select({ key: pluginStorage.key }).from(pluginStorage)
+              .where(eq(pluginStorage.pluginName, manifest.name))
+              .all()
+        return rows.map(r => r.key)
+      },
+      async clear(): Promise<void> {
+        await db.delete(pluginStorage).where(eq(pluginStorage.pluginName, manifest.name))
+      },
+    }
+
+    // HTTP client with permission checking
+    const allowedHosts = (manifest.permissions ?? [])
+      .filter(p => p.startsWith('http:'))
+      .map(p => p.slice(5))
+
+    const http: PluginHTTPClient = {
+      async fetch(url: string, init?: RequestInit): Promise<Response> {
+        const parsed = new URL(url)
+        const hostname = parsed.hostname
+
+        const allowed = allowedHosts.some(pattern => {
+          if (pattern.startsWith('*.')) {
+            return hostname.endsWith(pattern.slice(1)) || hostname === pattern.slice(2)
+          }
+          return hostname === pattern
+        })
+
+        if (!allowed) {
+          throw new Error(`Plugin "${manifest.name}" does not have permission to access "${hostname}". Declare "http:${hostname}" in permissions.`)
+        }
+
+        return globalThis.fetch(url, init)
+      },
+    }
+
+    return {
+      config,
+      log: pluginLog as unknown as PluginLogger,
+      storage,
+      http,
+      manifest,
+    }
+  }
+
+  // ─── State management ──────────────────────────────────────────────────────
+
+  private async getState(name: string) {
+    return db.select().from(pluginStates).where(eq(pluginStates.name, name)).get()
+  }
+
+  private async setState(name: string, enabled: boolean): Promise<void> {
+    const now = new Date()
+    const existing = await this.getState(name)
+    if (existing) {
+      await db.update(pluginStates).set({ enabled, updatedAt: now }).where(eq(pluginStates.name, name))
+    } else {
+      await db.insert(pluginStates).values({ name, enabled, createdAt: now, updatedAt: now })
+    }
+  }
+
+  // ─── Config management ─────────────────────────────────────────────────────
+
+  async getResolvedConfig(name: string): Promise<Record<string, any>> {
+    const plugin = this.plugins.get(name)
+    if (!plugin) return {}
+
+    const state = await this.getState(name)
+    if (!state?.configEncrypted) {
+      // Return defaults
+      const defaults: Record<string, any> = {}
+      if (plugin.manifest.config) {
+        for (const [key, field] of Object.entries(plugin.manifest.config)) {
+          if (field.default !== undefined) {
+            defaults[key] = field.default
+          }
+        }
+      }
+      return defaults
+    }
+
+    try {
+      const decrypted = await decrypt(state.configEncrypted)
+      return JSON.parse(decrypted)
+    } catch {
+      return {}
+    }
+  }
+
+  /** Get config for API (secrets masked) */
+  async getConfigForAPI(name: string): Promise<Record<string, any>> {
+    const config = await this.getResolvedConfig(name)
+    const plugin = this.plugins.get(name)
+    if (!plugin?.manifest.config) return config
+
+    const masked = { ...config }
+    for (const [key, field] of Object.entries(plugin.manifest.config)) {
+      if (field.secret && masked[key]) {
+        masked[key] = '••••••••'
+      }
+    }
+    return masked
+  }
+
+  async setConfig(name: string, config: Record<string, any>): Promise<void> {
+    const plugin = this.plugins.get(name)
+    if (!plugin) throw new Error(`Plugin "${name}" not found`)
+
+    // Merge with existing config (preserve secrets that are masked)
+    const existing = await this.getResolvedConfig(name)
+    const merged = { ...existing }
+
+    for (const [key, value] of Object.entries(config)) {
+      // Don't overwrite secrets with the mask value
+      if (value === '••••••••' && plugin.manifest.config?.[key]?.secret) {
+        continue
+      }
+      merged[key] = value
+    }
+
+    const encrypted = await encrypt(JSON.stringify(merged))
+    const now = new Date()
+    const state = await this.getState(name)
+
+    if (state) {
+      await db.update(pluginStates).set({ configEncrypted: encrypted, updatedAt: now }).where(eq(pluginStates.name, name))
+    } else {
+      await db.insert(pluginStates).values({ name, enabled: false, configEncrypted: encrypted, createdAt: now, updatedAt: now })
+    }
+
+    // If plugin is enabled, re-activate with new config
+    if (plugin.enabled) {
+      await this.deactivatePlugin(name)
+      await this.activatePlugin(name)
+    }
+  }
+
+  // ─── Public API ────────────────────────────────────────────────────────────
+
+  async enablePlugin(name: string): Promise<void> {
+    const plugin = this.plugins.get(name)
+    if (!plugin) throw new Error(`Plugin "${name}" not found`)
+
+    await this.setState(name, true)
+    await this.activatePlugin(name)
+  }
+
+  async disablePlugin(name: string): Promise<void> {
+    const plugin = this.plugins.get(name)
+    if (!plugin) throw new Error(`Plugin "${name}" not found`)
+
+    await this.setState(name, false)
+    await this.deactivatePlugin(name)
+  }
+
+  /** List all discovered plugins as summaries */
+  listPlugins(): PluginSummary[] {
+    return Array.from(this.plugins.values()).map(p => ({
+      name: p.manifest.name,
+      version: p.manifest.version,
+      description: p.manifest.description,
+      author: p.manifest.author,
+      homepage: p.manifest.homepage,
+      license: p.manifest.license,
+      icon: p.manifest.icon,
+      permissions: p.manifest.permissions ?? [],
+      enabled: p.enabled,
+      error: p.error,
+      toolCount: p.registeredTools.length,
+      hookCount: p.registeredHooks.length,
+      configSchema: p.manifest.config ?? {},
+    }))
+  }
+
+  getPlugin(name: string): LoadedPlugin | undefined {
+    return this.plugins.get(name)
+  }
+
+  /** Get tool names provided by a specific plugin */
+  getPluginToolNames(name: string): string[] {
+    return this.plugins.get(name)?.registeredTools ?? []
+  }
+
+  /** Get all plugin tool names (for UI) */
+  getAllPluginToolNames(): string[] {
+    return Array.from(this.plugins.values()).flatMap(p => p.registeredTools)
+  }
+
+  /** Reload all plugins (rescan) */
+  async reload(): Promise<void> {
+    // Deactivate all
+    for (const [name, plugin] of this.plugins) {
+      if (plugin.enabled) {
+        await this.deactivatePlugin(name)
+      }
+    }
+    this.plugins.clear()
+    await this.scan()
+  }
+}
+
+export const pluginManager = new PluginManager()

--- a/src/shared/types/plugin.ts
+++ b/src/shared/types/plugin.ts
@@ -1,0 +1,48 @@
+// ─── Plugin System Types ─────────────────────────────────────────────────────
+
+export interface PluginConfigField {
+  type: 'string' | 'number' | 'boolean' | 'select' | 'text'
+  label: string
+  description?: string
+  required?: boolean
+  default?: any
+  secret?: boolean
+  // type-specific
+  options?: string[]       // select
+  min?: number             // number
+  max?: number             // number
+  step?: number            // number
+  placeholder?: string     // string, text
+  pattern?: string         // string
+  rows?: number            // text
+}
+
+export interface PluginManifest {
+  name: string
+  version: string
+  description: string
+  author?: string
+  homepage?: string
+  license?: string
+  kinbot?: string
+  main: string
+  icon?: string
+  permissions?: string[]
+  config?: Record<string, PluginConfigField>
+}
+
+export interface PluginSummary {
+  name: string
+  version: string
+  description: string
+  author?: string
+  homepage?: string
+  license?: string
+  icon?: string
+  permissions: string[]
+  enabled: boolean
+  error?: string
+  toolCount: number
+  hookCount: number
+  configSchema: Record<string, PluginConfigField>
+}


### PR DESCRIPTION
Implements the plugin/extension system as specified in PLUGIN-SPEC.md.

## What this adds
- **Plugin loader** (`src/server/services/plugins.ts`): scans `plugins/` for folders with `plugin.json` manifests, validates structure, loads TypeScript entry points via Bun
- **PluginContext API**: config (encrypted storage, secrets masked in API), scoped key-value storage, scoped logger, HTTP client (permission-gated)
- **Tool and hook registration** from plugins into existing `toolRegistry` and `hookRegistry`
- **REST API** for plugin management: `GET /api/plugins`, `POST .../enable|disable`, `GET|PUT .../config`, `POST /api/plugins/reload`
- **Plugin management UI** in Settings > Plugins (list, enable/disable toggle, auto-generated config forms from manifest schema, permission viewer)
- **DB migration**: `plugin_states` and `plugin_storage` tables
- **Example weather plugin** (`plugins/example-weather/`) as documentation-by-example
- **13 tests** for manifest validation
- **i18n** keys (en + fr)

## Plugin structure
```
plugins/my-plugin/
  plugin.json    # Manifest (name, version, tools, config schema, permissions)
  index.ts       # Entry point exporting default function(ctx) => { tools, hooks, activate, deactivate }
```

## How to test
1. Check the example plugin in `plugins/example-weather/`
2. Enable it in Settings > Plugins
3. Configure an OpenWeatherMap API key
4. Assign the `plugin_example-weather_get_weather` tool to a Kin
5. Ask the Kin about weather

## Not in this PR (future phases per spec)
- Provider and channel registration from plugins
- Plugin install from git URL / npm
- Community registry
- True sandboxing (VM/worker threads)
- Hot reload of code changes without restart
- Per-Kin plugin tool selection UI tab (tools are opt-in via existing enabledOptInTools mechanism)

See `PLUGIN-SPEC.md` for full documentation.