### PR TITLE
feat(store): add RSS reader plugin and store directory

### DIFF
--- a/registry/registry.json
+++ b/registry/registry.json
@@ -28,5 +28,21 @@
     "homepage": "https://github.com/MarlBurroW/kinbot-plugin-example-provider",
     "license": "MIT",
     "readme_url": "https://raw.githubusercontent.com/MarlBurroW/kinbot-plugin-example-provider/main/README.md"
+  },
+  {
+    "name": "rss-reader",
+    "description": "Fetch and summarize RSS/Atom feeds. Let your Kin stay up to date with news, blogs, and podcasts.",
+    "author": "KinBot Team",
+    "version": "1.0.0",
+    "repo": "https://github.com/MarlBurroW/kinbot",
+    "tags": ["rss", "news", "tools", "productivity"],
+    "downloads": 0,
+    "rating": 0,
+    "compatible_versions": ">=0.10.0",
+    "icon": "📰",
+    "homepage": "https://github.com/MarlBurroW/kinbot/tree/main/store/rss-reader",
+    "license": "MIT",
+    "readme_url": "https://raw.githubusercontent.com/MarlBurroW/kinbot/main/store/rss-reader/README.md",
+    "store": true
   }
 ]

--- a/store/README.md
+++ b/store/README.md
@@ -1,0 +1,18 @@
+# KinBot Plugin Store
+
+Official community plugins for KinBot. Each directory contains a self-contained plugin that can be installed directly from the KinBot UI.
+
+## Available Plugins
+
+| Plugin | Description | Tags |
+|--------|-------------|------|
+| [rss-reader](./rss-reader/) | Fetch and summarize RSS/Atom feeds | rss, news, productivity |
+
+## Contributing
+
+1. Fork this repo
+2. Create your plugin in `store/<plugin-name>/`
+3. Include: `plugin.json`, `index.ts`, `README.md`
+4. Open a PR - maintainers will review and merge
+
+See the [Plugin Development Guide](../docs/plugins.md) for details on the plugin API.

--- a/store/rss-reader/README.md
+++ b/store/rss-reader/README.md
@@ -1,0 +1,44 @@
+# 📰 RSS Reader
+
+Fetch and summarize RSS/Atom feeds directly from your Kin conversations.
+
+## Features
+
+- **Parse RSS 2.0 and Atom feeds** - works with most news sites, blogs, and podcasts
+- **Configurable default feeds** - set your favorite sources once, fetch anytime
+- **No API key required** - just point it at a feed URL
+
+## Tools
+
+### `fetch_rss`
+
+Fetch and parse an RSS or Atom feed.
+
+**Parameters:**
+- `url` (optional) - Feed URL. Falls back to configured defaults.
+- `maxItems` (optional) - Max items to return (1-50).
+
+**Example prompts:**
+- "What's on Hacker News right now?"
+- "Fetch the latest posts from https://feeds.arstechnica.com/arstechnica/index"
+- "Give me the top 5 items from my default feed"
+
+### `list_default_feeds`
+
+List configured default feed URLs.
+
+## Configuration
+
+| Setting | Description |
+|---------|-------------|
+| **Default Feed URLs** | Comma-separated list of RSS/Atom URLs |
+| **Default Max Items** | How many items to return per fetch (5/10/15/20) |
+
+## Popular Feed URLs
+
+- Hacker News: `https://hnrss.org/frontpage`
+- Ars Technica: `https://feeds.arstechnica.com/arstechnica/index`
+- TechCrunch: `https://techcrunch.com/feed/`
+- The Verge: `https://www.theverge.com/rss/index.xml`
+- BBC News: `https://feeds.bbci.co.uk/news/rss.xml`
+- Reddit (any sub): `https://www.reddit.com/r/programming/.rss`

--- a/store/rss-reader/index.ts
+++ b/store/rss-reader/index.ts
@@ -1,0 +1,213 @@
+import { tool } from 'ai'
+import { z } from 'zod'
+
+/**
+ * RSS Reader plugin for KinBot.
+ * Provides tools to fetch, parse, and summarize RSS/Atom feeds.
+ */
+
+interface FeedItem {
+  title: string
+  link: string
+  description: string
+  pubDate: string
+  author?: string
+}
+
+interface ParsedFeed {
+  title: string
+  description: string
+  link: string
+  items: FeedItem[]
+}
+
+/** Minimal XML tag content extractor */
+function getTagContent(xml: string, tag: string): string {
+  // Handle CDATA sections
+  const cdataPattern = new RegExp(`<${tag}[^>]*>\\s*<!\\[CDATA\\[([\\s\\S]*?)\\]\\]>\\s*</${tag}>`, 'i')
+  const cdataMatch = xml.match(cdataPattern)
+  if (cdataMatch) return cdataMatch[1].trim()
+
+  const pattern = new RegExp(`<${tag}[^>]*>([\\s\\S]*?)</${tag}>`, 'i')
+  const match = xml.match(pattern)
+  return match ? match[1].trim() : ''
+}
+
+/** Get attribute value from a tag */
+function getAttr(tag: string, attr: string): string {
+  const pattern = new RegExp(`${attr}\\s*=\\s*["']([^"']*)["']`, 'i')
+  const match = tag.match(pattern)
+  return match ? match[1] : ''
+}
+
+/** Strip HTML tags and decode basic entities */
+function stripHtml(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+/** Parse RSS 2.0 feed */
+function parseRSS(xml: string): ParsedFeed {
+  const channel = getTagContent(xml, 'channel')
+  const items: FeedItem[] = []
+
+  const itemMatches = xml.matchAll(/<item[\s>]([\s\S]*?)<\/item>/gi)
+  for (const m of itemMatches) {
+    const itemXml = m[1]
+    items.push({
+      title: stripHtml(getTagContent(itemXml, 'title')),
+      link: getTagContent(itemXml, 'link') || getTagContent(itemXml, 'guid'),
+      description: stripHtml(getTagContent(itemXml, 'description')).slice(0, 500),
+      pubDate: getTagContent(itemXml, 'pubDate'),
+      author: getTagContent(itemXml, 'dc:creator') || getTagContent(itemXml, 'author') || undefined,
+    })
+  }
+
+  return {
+    title: stripHtml(getTagContent(channel, 'title')),
+    description: stripHtml(getTagContent(channel, 'description')),
+    link: getTagContent(channel, 'link'),
+    items,
+  }
+}
+
+/** Parse Atom feed */
+function parseAtom(xml: string): ParsedFeed {
+  const items: FeedItem[] = []
+
+  const entryMatches = xml.matchAll(/<entry[\s>]([\s\S]*?)<\/entry>/gi)
+  for (const m of entryMatches) {
+    const entryXml = m[1]
+    // Atom links are in <link> attributes
+    const linkMatch = entryXml.match(/<link[^>]*href\s*=\s*["']([^"']*)["'][^>]*\/?>/i)
+    const link = linkMatch ? linkMatch[1] : ''
+
+    items.push({
+      title: stripHtml(getTagContent(entryXml, 'title')),
+      link,
+      description: stripHtml(
+        getTagContent(entryXml, 'summary') || getTagContent(entryXml, 'content')
+      ).slice(0, 500),
+      pubDate: getTagContent(entryXml, 'updated') || getTagContent(entryXml, 'published'),
+      author: getTagContent(getTagContent(entryXml, 'author'), 'name') || undefined,
+    })
+  }
+
+  // Feed-level metadata
+  const feedLinkMatch = xml.match(/<link[^>]*rel\s*=\s*["']alternate["'][^>]*href\s*=\s*["']([^"']*)["']/i)
+  const feedLink = feedLinkMatch ? feedLinkMatch[1] : ''
+
+  return {
+    title: stripHtml(getTagContent(xml, 'title')),
+    description: stripHtml(getTagContent(xml, 'subtitle') || ''),
+    link: feedLink,
+    items,
+  }
+}
+
+/** Detect feed type and parse accordingly */
+function parseFeed(xml: string): ParsedFeed {
+  if (xml.includes('<feed') && xml.includes('xmlns="http://www.w3.org/2005/Atom"')) {
+    return parseAtom(xml)
+  }
+  return parseRSS(xml)
+}
+
+export default function(ctx: any) {
+  const defaultMaxItems = parseInt(ctx.config.maxItems || '10', 10)
+  const defaultFeedUrls = (ctx.config.defaultFeeds || '')
+    .split(',')
+    .map((u: string) => u.trim())
+    .filter(Boolean)
+
+  return {
+    tools: {
+      fetch_rss: {
+        availability: ['main', 'sub-kin'] as const,
+        create: () =>
+          tool({
+            description:
+              'Fetch and parse an RSS or Atom feed. Returns the latest items with title, link, description, and date. ' +
+              'Use this to check news, blog posts, podcast episodes, or any RSS/Atom feed.',
+            inputSchema: z.object({
+              url: z.string().url().optional().describe(
+                'RSS/Atom feed URL. If omitted, uses the first configured default feed.'
+              ),
+              maxItems: z.number().min(1).max(50).optional().describe(
+                'Maximum number of items to return (default: configured max)'
+              ),
+            }),
+            execute: async ({ url, maxItems }: { url?: string; maxItems?: number }) => {
+              const feedUrl = url || defaultFeedUrls[0]
+              if (!feedUrl) {
+                return {
+                  error: 'No feed URL provided and no default feeds configured. Provide a URL or configure default feeds in plugin settings.',
+                }
+              }
+
+              const limit = maxItems || defaultMaxItems
+
+              try {
+                const res = await ctx.http.fetch(feedUrl, {
+                  headers: { 'Accept': 'application/rss+xml, application/atom+xml, application/xml, text/xml' },
+                })
+                const text = await res.text()
+                const feed = parseFeed(text)
+
+                return {
+                  feed: {
+                    title: feed.title,
+                    description: feed.description,
+                    link: feed.link,
+                  },
+                  items: feed.items.slice(0, limit).map((item) => ({
+                    title: item.title,
+                    link: item.link,
+                    description: item.description,
+                    date: item.pubDate,
+                    author: item.author,
+                  })),
+                  total: feed.items.length,
+                  showing: Math.min(feed.items.length, limit),
+                }
+              } catch (err: any) {
+                ctx.log.error({ err, url: feedUrl }, 'Failed to fetch RSS feed')
+                return { error: `Failed to fetch feed: ${err.message || 'Unknown error'}` }
+              }
+            },
+          }),
+      },
+
+      list_default_feeds: {
+        availability: ['main', 'sub-kin'] as const,
+        create: () =>
+          tool({
+            description: 'List the configured default RSS/Atom feed URLs.',
+            inputSchema: z.object({}),
+            execute: async () => {
+              if (defaultFeedUrls.length === 0) {
+                return { feeds: [], message: 'No default feeds configured. Go to Settings > Plugins to add some.' }
+              }
+              return { feeds: defaultFeedUrls }
+            },
+          }),
+      },
+    },
+
+    async activate() {
+      ctx.log.info({ defaultFeeds: defaultFeedUrls.length }, 'RSS Reader plugin activated')
+    },
+
+    async deactivate() {
+      ctx.log.info('RSS Reader plugin deactivated')
+    },
+  }
+}

--- a/store/rss-reader/plugin.json
+++ b/store/rss-reader/plugin.json
@@ -1,0 +1,28 @@
+{
+  "name": "rss-reader",
+  "version": "1.0.0",
+  "description": "Fetch and summarize RSS/Atom feeds. Let your Kin stay up to date with news, blogs, and podcasts.",
+  "author": "KinBot Team",
+  "license": "MIT",
+  "main": "index.ts",
+  "icon": "📰",
+  "tags": ["rss", "news", "tools", "productivity"],
+  "permissions": [
+    "http:*"
+  ],
+  "config": {
+    "defaultFeeds": {
+      "type": "string",
+      "label": "Default Feed URLs",
+      "description": "Comma-separated list of RSS/Atom feed URLs to use when no URL is specified",
+      "placeholder": "https://hnrss.org/frontpage, https://feeds.arstechnica.com/arstechnica/index"
+    },
+    "maxItems": {
+      "type": "select",
+      "label": "Default Max Items",
+      "description": "Maximum number of items to return per feed",
+      "options": ["5", "10", "15", "20"],
+      "default": "10"
+    }
+  }
+}


### PR DESCRIPTION
Initializes the store/ directory for in-repo community plugins (Raycast model, ref #53).

**Changes:**
- store/ directory with RSS Reader plugin (fetch/parse RSS 2.0 + Atom feeds, no API key needed)
- Updated registry.json with store: true flag for in-repo plugins
- store/README.md with contributing guidelines

**Next:** Store API install endpoints, more plugins, CI validation.