### PR TITLE
feat(plugins): Store install API endpoints

### DIFF
--- a/src/server/routes/plugins.ts
+++ b/src/server/routes/plugins.ts
@@ -3,8 +3,8 @@ import { pluginManager } from '@/server/services/plugins'
 import { pluginRegistry } from '@/server/services/pluginRegistry'
 import type { AppVariables } from '@/server/app'
 import { createLogger } from '@/server/logger'
-import { readFile } from 'fs/promises'
-import { resolve } from 'path'
+import { readFile, readdir, access } from 'fs/promises'
+import { resolve, join } from 'path'
 
 const log = createLogger('routes:plugins')
 
@@ -59,6 +59,89 @@ pluginRoutes.get('/version', async (c) => {
     return c.json({ version: pkg.version })
   } catch {
     return c.json({ version: '0.0.0' })
+  }
+})
+
+// ─── Store routes ────────────────────────────────────────────────────────────
+
+// GET /api/plugins/store — list available store plugins
+pluginRoutes.get('/store', async (c) => {
+  try {
+    const storeDir = resolve(process.cwd(), 'store')
+    let entries: string[]
+    try {
+      entries = await readdir(storeDir)
+    } catch {
+      return c.json({ plugins: [] })
+    }
+
+    const installedPlugins = pluginManager.listPlugins()
+    const installedNames = new Set(installedPlugins.map(p => p.name))
+
+    const plugins = []
+    for (const entry of entries) {
+      if (entry.startsWith('.') || entry === 'README.md') continue
+      try {
+        const manifestPath = join(storeDir, entry, 'plugin.json')
+        await access(manifestPath)
+        const raw = await readFile(manifestPath, 'utf-8')
+        const manifest = JSON.parse(raw)
+        plugins.push({
+          ...manifest,
+          dirName: entry,
+          installed: installedNames.has(manifest.name),
+        })
+      } catch {
+        // Skip invalid entries
+      }
+    }
+
+    return c.json({ plugins })
+  } catch (err) {
+    log.error({ err }, 'Failed to list store plugins')
+    return c.json({ error: { code: 'STORE_LIST_FAILED', message: 'Failed to list store plugins' } }, 500)
+  }
+})
+
+// GET /api/plugins/store/:name — get store plugin details + README
+pluginRoutes.get('/store/:name', async (c) => {
+  const { name } = c.req.param()
+  try {
+    const pluginDir = resolve(process.cwd(), 'store', name)
+    const manifestPath = join(pluginDir, 'plugin.json')
+    const raw = await readFile(manifestPath, 'utf-8')
+    const manifest = JSON.parse(raw)
+
+    let readme: string | null = null
+    try {
+      readme = await readFile(join(pluginDir, 'README.md'), 'utf-8')
+    } catch {
+      // No README
+    }
+
+    const installedPlugins = pluginManager.listPlugins()
+    const installed = installedPlugins.some(p => p.name === manifest.name)
+
+    return c.json({ ...manifest, dirName: name, installed, readme })
+  } catch {
+    return c.json({ error: { code: 'STORE_PLUGIN_NOT_FOUND', message: `Store plugin "${name}" not found` } }, 404)
+  }
+})
+
+// POST /api/plugins/store/:name/install — install a store plugin
+pluginRoutes.post('/store/:name/install', async (c) => {
+  const { name } = c.req.param()
+  try {
+    const result = await pluginManager.installFromStore(name)
+    return c.json({ success: true, name: result.name })
+  } catch (err) {
+    log.error({ plugin: name, err }, 'Failed to install store plugin')
+    return c.json({
+      error: {
+        code: 'STORE_INSTALL_FAILED',
+        message: err instanceof Error ? err.message : 'Failed to install store plugin',
+      },
+    }, 400)
   }
 })
 

--- a/src/server/services/plugins.ts
+++ b/src/server/services/plugins.ts
@@ -875,6 +875,95 @@ class PluginManager {
     }
   }
 
+  /** Install a plugin from the in-repo store/ directory */
+  async installFromStore(storeName: string): Promise<{ name: string }> {
+    const storeDir = resolve(process.cwd(), 'store', storeName)
+
+    // Verify the store plugin exists
+    let raw: string
+    try {
+      raw = await readFile(join(storeDir, 'plugin.json'), 'utf-8')
+    } catch {
+      throw new Error(`Store plugin "${storeName}" not found`)
+    }
+
+    const data = JSON.parse(raw)
+    const validation = validateManifest(data)
+    if (!validation.valid) {
+      throw new Error(`Invalid manifest: ${validation.errors.join('; ')}`)
+    }
+
+    const manifest = data as PluginManifest
+
+    // Check if already installed
+    if (this.plugins.has(manifest.name)) {
+      throw new Error(`Plugin "${manifest.name}" is already installed`)
+    }
+
+    await mkdir(this.pluginsDir, { recursive: true })
+    const targetDir = join(this.pluginsDir, manifest.name)
+
+    // Copy store plugin to plugins directory
+    const cpProc = Bun.spawn(['cp', '-r', storeDir, targetDir], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const exitCode = await cpProc.exited
+    if (exitCode !== 0) {
+      const stderr = await new Response(cpProc.stderr).text()
+      throw new Error(`Failed to copy store plugin: ${stderr.trim()}`)
+    }
+
+    // Save install source in DB
+    const now = new Date()
+    const installMeta: PluginInstallMeta = {
+      version: manifest.version,
+      installedAt: now.toISOString(),
+    }
+
+    const existing = await this.getState(manifest.name)
+    if (existing) {
+      await db.update(pluginStates).set({
+        enabled: true,
+        installSource: 'store',
+        installMeta: JSON.stringify(installMeta),
+        updatedAt: now,
+      }).where(eq(pluginStates.name, manifest.name))
+    } else {
+      await db.insert(pluginStates).values({
+        name: manifest.name,
+        enabled: true,
+        installSource: 'store',
+        installMeta: JSON.stringify(installMeta),
+        createdAt: now,
+        updatedAt: now,
+      })
+    }
+
+    // Register and activate
+    this.plugins.set(manifest.name, {
+      manifest,
+      exports: null,
+      enabled: false,
+      registeredTools: [],
+      registeredHooks: [],
+      registeredProviders: [],
+      registeredChannels: [],
+      installSource: 'store',
+      installMeta,
+    })
+
+    await this.activatePlugin(manifest.name)
+
+    sseManager.broadcast({
+      type: 'plugin:installed',
+      data: { name: manifest.name, source: 'store' },
+    })
+
+    log.info({ plugin: manifest.name, storeName }, 'Plugin installed from store')
+    return { name: manifest.name }
+  }
+
   /** Uninstall a plugin: deactivate, remove files, clean DB */
   async uninstallPlugin(name: string): Promise<void> {
     const plugin = this.plugins.get(name)

--- a/src/shared/types/plugin.ts
+++ b/src/shared/types/plugin.ts
@@ -42,7 +42,7 @@ export interface PluginChannelMeta {
   displayName: string
 }
 
-export type PluginInstallSource = 'local' | 'git' | 'npm'
+export type PluginInstallSource = 'local' | 'git' | 'npm' | 'store'
 
 export interface PluginInstallMeta {
   url?: string        // git URL


### PR DESCRIPTION
Adds Store API endpoints for installing plugins from the in-repo store/ directory (Phase 2 of #53).

**New endpoints:**
- GET /api/plugins/store — list available store plugins
- GET /api/plugins/store/:name — plugin details + README
- POST /api/plugins/store/:name/install — install from store

**Changes:**
- Added 'store' to PluginInstallSource type
- Added installFromStore() method (copies store/ → plugins/, validates, activates)
- 3 new routes with error handling + SSE broadcast

**Next:** Store UI tab in Settings > Plugins (Phase 3)