### PR TITLE
fix: resolve test mock leakage causing 5 test failures

### DIFF
--- a/src/client/lib/cron-next.test.ts
+++ b/src/client/lib/cron-next.test.ts
@@ -49,7 +49,8 @@ describe('formatCountdown', () => {
   })
 
   it('returns minutes for < 1 hour', () => {
-    const date = new Date(Date.now() + 15 * 60_000)
+    // Add 30s buffer to avoid off-by-one from test execution time
+    const date = new Date(Date.now() + 15 * 60_000 + 30_000)
     expect(formatCountdown(date)).toBe('15m')
   })
 

--- a/src/server/auth/middleware.test.ts
+++ b/src/server/auth/middleware.test.ts
@@ -28,6 +28,8 @@ mock.module('@/server/db/index', () => ({
       }),
     }),
   },
+  sqlite: {},
+  initVirtualTables: () => {},
 }))
 
 // ─── Import after mocking ────────────────────────────────────────────────────

--- a/src/server/routes/onboarding.test.ts
+++ b/src/server/routes/onboarding.test.ts
@@ -54,33 +54,30 @@ mock.module('@/server/db/index', () => {
       insert: (...args: unknown[]) => mockDbInsert(...args),
       update: (...args: unknown[]) => mockDbUpdate(...args),
     },
+    sqlite: {},
+    initVirtualTables: () => {},
   }
 })
 
-// Include all commonly-used schema exports to prevent mock leak breaking sibling test files
+// Include ALL schema exports to prevent mock leak breaking sibling test files
 mock.module('@/server/db/schema', () => ({
-  userProfiles: { role: 'role', userId: 'user_id' },
-  providers: { id: 'id' },
   user: { id: 'id' },
-  kins: { id: 'id', toolConfig: 'toolConfig' },
-  files: { id: 'id' },
-  messages: { id: 'id' },
-  memories: { id: 'id' },
-  contacts: { id: 'id' },
   session: { id: 'id' },
   account: { id: 'id' },
+  verification: { id: 'id' },
+  userProfiles: { role: 'role', userId: 'user_id' },
+  providers: { id: 'id' },
+  kins: { id: 'id', toolConfig: 'toolConfig' },
+  mcpServers: { id: 'id' },
+  kinMcpServers: { id: 'id' },
+  messages: { id: 'id' },
   compactingSnapshots: { id: 'id' },
-  humanPrompts: { id: 'id' },
-  messageReactions: { id: 'id' },
-  channels: { id: 'id' },
-  channelUserMappings: { id: 'id' },
-  invitations: { id: 'id' },
+  memories: { id: 'id' },
+  contacts: { id: 'id' },
   contactIdentifiers: { id: 'id' },
   contactPlatformIds: { id: 'id' },
   contactNotes: { id: 'id' },
   customTools: { id: 'id' },
-  mcpServers: { id: 'id' },
-  kinMcpServers: { id: 'id' },
   quickSessions: { id: 'id' },
   tasks: { id: 'id' },
   crons: { id: 'id' },
@@ -90,8 +87,24 @@ mock.module('@/server/db/schema', () => ({
   vaultTypes: { id: 'id' },
   vaultAttachments: { id: 'id' },
   queueItems: { id: 'id' },
-  verification: { id: 'id' },
+  files: { id: 'id' },
+  humanPrompts: { id: 'id' },
+  channels: { id: 'id' },
+  channelUserMappings: { id: 'id' },
+  channelMessageLinks: { id: 'id' },
+  invitations: { id: 'id' },
   notifications: { id: 'id' },
+  notificationPreferences: { id: 'id' },
+  notificationChannels: { id: 'id' },
+  scheduledWakeups: { id: 'id' },
+  messageReactions: { id: 'id' },
+  appSettings: { id: 'id' },
+  miniApps: { id: 'id' },
+  miniAppStorage: { id: 'id' },
+  miniAppSnapshots: { id: 'id' },
+  fileStorage: { id: 'id' },
+  pluginStates: { id: 'id' },
+  pluginStorage: { id: 'id' },
 }))
 
 // Stub all commonly-used drizzle-orm operators to prevent mock leak
@@ -130,6 +143,10 @@ mock.module('@/server/services/contacts', () => ({
 mock.module('@/server/services/invitations', () => ({
   validateInvitation: (...args: unknown[]) => mockValidateInvitation(...args),
   markInvitationUsed: (...args: unknown[]) => mockMarkInvitationUsed(...args),
+  createInvitation: () => ({}),
+  buildInvitationUrl: () => '',
+  listInvitations: () => [],
+  revokeInvitation: () => ({ success: true }),
 }))
 
 // ─── Import after mocking ───────────────────────────────────────────────────

--- a/src/server/tools/user-tools.test.ts
+++ b/src/server/tools/user-tools.test.ts
@@ -42,6 +42,10 @@ const mockCreateInvitation = mock(() =>
 mock.module('@/server/services/invitations', () => ({
   createInvitation: mockCreateInvitation,
   buildInvitationUrl: (token: string) => `https://kinbot.local/invite/${token}`,
+  validateInvitation: () => ({ valid: true }),
+  markInvitationUsed: () => true,
+  listInvitations: () => [],
+  revokeInvitation: () => ({ success: true }),
 }))
 
 mock.module('@/server/logger', () => ({

--- a/src/server/tools/wakeup-tools.test.ts
+++ b/src/server/tools/wakeup-tools.test.ts
@@ -27,6 +27,15 @@ mock.module('@/server/config', () => ({
       minDelaySeconds: 10,
       maxDelaySeconds: 2_592_000,
     },
+    upload: {
+      dir: '/tmp/test-uploads',
+      maxFileSizeMb: 50,
+      channelFileRetentionDays: 30,
+      channelFileCleanupIntervalMin: 60,
+    },
+    fileStorage: {
+      dir: '/tmp/test-storage',
+    },
   },
 }))
 


### PR DESCRIPTION
Bun mock.module is global - first mock for a module persists across all files. Added missing exports to leaking mocks. Before: 1806 pass, 5 fail. After: 1875 pass, 0 fail.