### PR TITLE
feat: per-Kin compacting thresholds + compaction proximity UI

### DIFF
--- a/src/client/components/chat/ChatPanel.tsx
+++ b/src/client/components/chat/ChatPanel.tsx
@@ -58,7 +58,7 @@ interface ChatPanelProps {
   kin: KinInfo
   llmModels: LLMModel[]
   modelUnavailable?: boolean
-  queueState?: { isProcessing: boolean; queueSize: number; contextTokens?: number; contextWindow?: number }
+  queueState?: { isProcessing: boolean; queueSize: number; contextTokens?: number; contextWindow?: number; compactingTokens?: number; compactingThreshold?: number; compactingMessages?: number; compactingMessageThreshold?: number }
   onModelChange: (model: string) => void
   onEditKin: () => void
 }
@@ -598,6 +598,10 @@ export function ChatPanel({ kin, llmModels, modelUnavailable = false, queueState
         messageCount={messages.length}
         estimatedTokens={queueState?.contextTokens ?? 0}
         maxTokens={queueState?.contextWindow ?? 0}
+        compactingTokens={queueState?.compactingTokens}
+        compactingThreshold={queueState?.compactingThreshold}
+        compactingMessages={queueState?.compactingMessages}
+        compactingMessageThreshold={queueState?.compactingMessageThreshold}
         toolCallCount={toolCallCount}
         isToolCallsOpen={isToolCallsOpen}
         queueState={queueState}

--- a/src/client/components/chat/ConversationHeader.tsx
+++ b/src/client/components/chat/ConversationHeader.tsx
@@ -61,6 +61,10 @@ interface ConversationHeaderProps {
   onExportJSON?: () => void
   onSearch?: () => void
   onClearConversation?: () => void
+  compactingTokens?: number
+  compactingThreshold?: number
+  compactingMessages?: number
+  compactingMessageThreshold?: number
   messages?: ChatMessage[]
   scrollViewportRef?: React.RefObject<HTMLElement | null>
 }
@@ -93,6 +97,10 @@ export const ConversationHeader = memo(function ConversationHeader({
   onExportJSON,
   onSearch,
   onClearConversation,
+  compactingTokens,
+  compactingThreshold,
+  compactingMessages,
+  compactingMessageThreshold,
   messages,
   scrollViewportRef,
 }: ConversationHeaderProps) {
@@ -108,6 +116,12 @@ export const ConversationHeader = memo(function ConversationHeader({
   const contextLabel = hasContextData
     ? `${formatTokenCount(estimatedTokens)} / ${formatTokenCount(maxTokens)}`
     : '— / —'
+
+  const hasCompactingData = (compactingThreshold ?? 0) > 0
+  const compactingRemaining = hasCompactingData ? Math.max(0, compactingThreshold! - (compactingTokens ?? 0)) : 0
+  const compactingPercent = hasCompactingData ? Math.min(100, Math.round(((compactingTokens ?? 0) / compactingThreshold!) * 100)) : 0
+  // Position of the compacting threshold marker on the context bar (as % of context window)
+  const compactingMarkerPercent = (hasCompactingData && hasContextData) ? Math.min(100, Math.round((compactingThreshold! / maxTokens) * 100)) : null
 
   const selectedModelName = llmModels.find((m) => m.id === model)?.name ?? model
 
@@ -194,11 +208,19 @@ export const ConversationHeader = memo(function ConversationHeader({
                 </span>
                 <span>{contextLabel}</span>
               </div>
-              <Progress
-                value={contextPercent}
-                variant={contextPercent > 80 ? 'glow' : 'default'}
-                className="h-2"
-              />
+              <div className="relative">
+                <Progress
+                  value={contextPercent}
+                  variant={contextPercent > 80 ? 'glow' : 'default'}
+                  className="h-2"
+                />
+                {compactingMarkerPercent != null && (
+                  <div
+                    className="absolute top-0 h-full w-px bg-foreground/50"
+                    style={{ left: `${compactingMarkerPercent}%` }}
+                  />
+                )}
+              </div>
               <p className="text-[10px] text-muted-foreground/70">
                 {hasContextData
                   ? t('chat.contextUsage', {
@@ -209,6 +231,16 @@ export const ConversationHeader = memo(function ConversationHeader({
                   : t('chat.contextNoData')}
               </p>
             </div>
+            {/* Compacting proximity */}
+            {hasCompactingData && (
+              <p className="text-[10px] text-muted-foreground/70">
+                {t('chat.compactingProximity', {
+                  tokens: formatTokenCount(compactingRemaining),
+                  messages: compactingMessages ?? 0,
+                  maxMessages: compactingMessageThreshold ?? 0,
+                })}
+              </p>
+            )}
           </PopoverContent>
         </Popover>
       </div>
@@ -223,7 +255,7 @@ export const ConversationHeader = memo(function ConversationHeader({
           className="h-7 w-auto max-w-[280px] text-xs"
         />
 
-        {/* Context usage */}
+        {/* Context usage + compacting proximity */}
         <Tooltip>
           <TooltipTrigger asChild>
             <div className="flex w-28 flex-col gap-1">
@@ -234,21 +266,83 @@ export const ConversationHeader = memo(function ConversationHeader({
                 </span>
                 <span>{contextLabel}</span>
               </div>
-              <Progress
-                value={contextPercent}
-                variant={contextPercent > 80 ? 'glow' : 'default'}
-                className="h-1.5"
-              />
+              <div className="relative">
+                <Progress
+                  value={contextPercent}
+                  variant={contextPercent > 80 ? 'glow' : 'default'}
+                  className="h-1.5"
+                />
+                {compactingMarkerPercent != null && (
+                  <div
+                    className="absolute top-0 h-full w-px bg-foreground/50"
+                    style={{ left: `${compactingMarkerPercent}%` }}
+                    title={t('chat.compactingMarker')}
+                  />
+                )}
+              </div>
+              {hasCompactingData && (
+                <p className="truncate text-[9px] text-muted-foreground">
+                  {t('chat.compactingProximity', {
+                    tokens: formatTokenCount(compactingRemaining),
+                    messages: compactingMessages ?? 0,
+                    maxMessages: compactingMessageThreshold ?? 0,
+                  })}
+                </p>
+              )}
             </div>
           </TooltipTrigger>
-          <TooltipContent side="bottom">
-            {hasContextData
-              ? t('chat.contextUsage', {
-                  tokens: formatTokenCount(estimatedTokens),
-                  max: formatTokenCount(maxTokens),
-                  percent: contextPercent,
-                })
-              : t('chat.contextNoData')}
+          <TooltipContent side="bottom" className="w-64 space-y-3 p-3">
+            {/* Context window */}
+            <div className="space-y-1.5">
+              <div className="flex items-center justify-between text-[11px]">
+                <span className="font-medium">{t('chat.tooltipContext')}</span>
+                <span className="text-muted-foreground">{contextLabel}</span>
+              </div>
+              <div className="relative">
+                <Progress
+                  value={contextPercent}
+                  variant={contextPercent > 80 ? 'glow' : 'default'}
+                  className="h-2.5"
+                />
+                {compactingMarkerPercent != null && (
+                  <div
+                    className="absolute top-0 h-full w-0.5 rounded-full bg-foreground/60"
+                    style={{ left: `${compactingMarkerPercent}%` }}
+                  />
+                )}
+              </div>
+              <p className="text-[10px] text-muted-foreground">
+                {hasContextData
+                  ? t('chat.contextUsage', {
+                      tokens: formatTokenCount(estimatedTokens),
+                      max: formatTokenCount(maxTokens),
+                      percent: contextPercent,
+                    })
+                  : t('chat.contextNoData')}
+              </p>
+            </div>
+
+            {/* Compacting proximity */}
+            {hasCompactingData && (
+              <div className="space-y-1.5 border-t border-border/40 pt-2.5">
+                <div className="flex items-center justify-between text-[11px]">
+                  <span className="font-medium">{t('chat.tooltipCompacting')}</span>
+                  <span className="text-muted-foreground">{compactingPercent}%</span>
+                </div>
+                <Progress
+                  value={compactingPercent}
+                  variant={compactingPercent > 80 ? 'glow' : 'default'}
+                  className="h-2.5"
+                />
+                <div className="flex items-center justify-between text-[10px] text-muted-foreground">
+                  <span>{t('chat.compactingProximity', {
+                    tokens: formatTokenCount(compactingRemaining),
+                    messages: compactingMessages ?? 0,
+                    maxMessages: compactingMessageThreshold ?? 0,
+                  })}</span>
+                </div>
+              </div>
+            )}
           </TooltipContent>
         </Tooltip>
       </div>

--- a/src/client/components/kin/KinFormModal.tsx
+++ b/src/client/components/kin/KinFormModal.tsx
@@ -22,14 +22,14 @@ import { AvatarPickerModal, type AvatarPickerResult } from '@/client/components/
 import { KinToolsTab } from '@/client/components/kin/KinToolsTab'
 import { MemoryList } from '@/client/components/memory/MemoryList'
 import { Switch } from '@/client/components/ui/switch'
-import { ArrowLeft, Bot, Brain, Camera, Loader2, Network, Settings, ShieldCheck, Sparkles, Trash2, Upload, User, Wrench } from 'lucide-react'
+import { Archive, ArrowLeft, Bot, Brain, Camera, Loader2, Network, Settings, ShieldCheck, Sparkles, Trash2, Upload, User, Wrench } from 'lucide-react'
 import { InfoTip } from '@/client/components/common/InfoTip'
 import { UnsavedChangesDialog } from '@/client/components/common/UnsavedChangesDialog'
 import { useUnsavedChanges } from '@/client/hooks/useUnsavedChanges'
 import { cn } from '@/client/lib/utils'
 import { getErrorMessage } from '@/client/lib/api'
 import { TOOL_DOMAIN_MAP } from '@/shared/constants'
-import type { KinToolConfig } from '@/shared/types'
+import type { KinToolConfig, KinCompactingConfig } from '@/shared/types'
 import type { GeneratedKinConfig } from '@/client/hooks/useKins'
 
 interface Model {
@@ -52,6 +52,7 @@ interface KinDetail {
   model: string
   providerId?: string | null
   toolConfig?: KinToolConfig | null
+  compactingConfig?: KinCompactingConfig | null
   isHub?: boolean
 }
 
@@ -192,6 +193,7 @@ export function KinFormModal({
   const [model, setModel] = useState('')
   const [providerId, setProviderId] = useState<string | null>(null)
   const [toolConfig, setToolConfig] = useState<KinToolConfig | null>(null)
+  const [compactingConfig, setCompactingConfig] = useState<KinCompactingConfig | null>(null)
   const [avatarFile, setAvatarFile] = useState<File | null>(null)
   const [avatarPreview, setAvatarPreview] = useState<string | null>(null)
   const [showAvatarPicker, setShowAvatarPicker] = useState(false)
@@ -238,6 +240,7 @@ export function KinFormModal({
       setModel(kin.model)
       setProviderId(kin.providerId ?? null)
       setToolConfig(kin.toolConfig ?? null)
+      setCompactingConfig(kin.compactingConfig ?? null)
       setAvatarPreview(kin.avatarUrl)
       setWizardStep('form')
       setWasAiGenerated(false)
@@ -250,6 +253,7 @@ export function KinFormModal({
       setModel('')
       setProviderId(null)
       setToolConfig(null)
+      setCompactingConfig(null)
       setAvatarPreview(null)
       setWizardStep('describe')
       setWasAiGenerated(false)
@@ -416,7 +420,11 @@ export function KinFormModal({
 
     try {
       if (isEdit && onUpdateKin) {
-        await onUpdateKin(kin.id, { name, slug, role, character, expertise, model, providerId, toolConfig })
+        // Normalize compactingConfig: if both fields are empty, send null to clear the override
+        const effectiveCompactingConfig = (compactingConfig?.messageThreshold != null || compactingConfig?.tokenThreshold != null)
+          ? compactingConfig
+          : null
+        await onUpdateKin(kin.id, { name, slug, role, character, expertise, model, providerId, toolConfig, compactingConfig: effectiveCompactingConfig })
         if (avatarFile) await onUploadAvatar(kin.id, avatarFile)
       } else if (onCreateKin) {
         const created = await onCreateKin({ name, slug: slug || undefined, role, character, expertise, model, providerId })
@@ -841,6 +849,7 @@ export function KinFormModal({
                               <span>{t('kin.create.totalPromptTokens', { tokens: Math.ceil((character.length + expertise.length) / 4) })}</span>
                             </div>
                           )}
+
                         </div>
                       )}
 
@@ -854,7 +863,51 @@ export function KinFormModal({
                       )}
 
                       {activeTab === 'memory' && isEdit && (
-                        <MemoryList kinId={kin.id} compact />
+                        <div className="space-y-6">
+                          <MemoryList kinId={kin.id} compact />
+
+                          {/* Compacting thresholds */}
+                          <div className="space-y-3 border-t border-border/40 pt-4">
+                            <Label className="inline-flex items-center gap-1.5 text-sm font-medium">
+                              <Archive className="size-4" />
+                              {t('kin.compacting.title')}
+                            </Label>
+                            <p className="text-xs text-muted-foreground">{t('kin.compacting.overrideHint')}</p>
+                            <div className="grid grid-cols-2 gap-3">
+                              <div className="space-y-1.5">
+                                <Label className="text-xs">{t('kin.compacting.messageThreshold')}</Label>
+                                <Input
+                                  type="number"
+                                  min={1}
+                                  placeholder={t('kin.compacting.messageThresholdPlaceholder', { default: 50 })}
+                                  value={compactingConfig?.messageThreshold ?? ''}
+                                  onChange={(e) => {
+                                    const val = e.target.value ? Number(e.target.value) : null
+                                    setCompactingConfig({ ...compactingConfig, messageThreshold: val, tokenThreshold: compactingConfig?.tokenThreshold ?? null })
+                                    markDirty()
+                                  }}
+                                />
+                                <p className="text-[10px] text-muted-foreground">{t('kin.compacting.messageThresholdHint', { default: 50 })}</p>
+                              </div>
+                              <div className="space-y-1.5">
+                                <Label className="text-xs">{t('kin.compacting.tokenThreshold')}</Label>
+                                <Input
+                                  type="number"
+                                  min={1000}
+                                  step={1000}
+                                  placeholder={t('kin.compacting.tokenThresholdPlaceholder', { default: '30k' })}
+                                  value={compactingConfig?.tokenThreshold ?? ''}
+                                  onChange={(e) => {
+                                    const val = e.target.value ? Number(e.target.value) : null
+                                    setCompactingConfig({ ...compactingConfig, tokenThreshold: val, messageThreshold: compactingConfig?.messageThreshold ?? null })
+                                    markDirty()
+                                  }}
+                                />
+                                <p className="text-[10px] text-muted-foreground">{t('kin.compacting.tokenThresholdHint', { default: '30k' })}</p>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
                       )}
 
                       {activeTab === 'memory' && !isEdit && (

--- a/src/client/hooks/useKins.ts
+++ b/src/client/hooks/useKins.ts
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { api } from '@/client/lib/api'
 import { useSSE, useSSEStatus } from '@/client/hooks/useSSE'
 import { useModels, type ProviderModel } from '@/client/hooks/useModels'
-import type { KinToolConfig } from '@/shared/types'
+import type { KinToolConfig, KinCompactingConfig } from '@/shared/types'
 
 interface KinSummary {
   id: string
@@ -21,6 +21,7 @@ interface KinDetail extends KinSummary {
   expertise: string
   workspacePath: string
   toolConfig: KinToolConfig | null
+  compactingConfig: KinCompactingConfig | null
   mcpServers: { id: string; name: string }[]
   queueSize: number
   isProcessing: boolean
@@ -58,6 +59,7 @@ interface UpdateKinData {
   model?: string
   providerId?: string | null
   toolConfig?: KinToolConfig | null
+  compactingConfig?: KinCompactingConfig | null
 }
 
 interface UserProfile {
@@ -112,7 +114,7 @@ export function useKins() {
   }, [sseStatus, fetchKins])
 
   // Track which kins are currently processing (queue state from SSE)
-  const [kinQueueState, setKinQueueState] = useState<Map<string, { isProcessing: boolean; queueSize: number; contextTokens?: number; contextWindow?: number }>>(new Map())
+  const [kinQueueState, setKinQueueState] = useState<Map<string, { isProcessing: boolean; queueSize: number; contextTokens?: number; contextWindow?: number; compactingTokens?: number; compactingThreshold?: number; compactingMessages?: number; compactingMessageThreshold?: number }>>(new Map())
 
   // Listen for kin lifecycle and queue updates via SSE to keep the list in sync
   useSSE({
@@ -174,6 +176,10 @@ export function useKins() {
           // Keep previous context info when not provided (end-of-processing events omit it)
           contextTokens: (data.contextTokens as number | undefined) ?? existing?.contextTokens,
           contextWindow: (data.contextWindow as number | undefined) ?? existing?.contextWindow,
+          compactingTokens: (data.compactingTokens as number | undefined) ?? existing?.compactingTokens,
+          compactingThreshold: (data.compactingThreshold as number | undefined) ?? existing?.compactingThreshold,
+          compactingMessages: (data.compactingMessages as number | undefined) ?? existing?.compactingMessages,
+          compactingMessageThreshold: (data.compactingMessageThreshold as number | undefined) ?? existing?.compactingMessageThreshold,
         })
         return next
       })
@@ -210,7 +216,7 @@ export function useKins() {
   // Fetch initial context usage for a kin (so the counter doesn't show "— / —")
   const fetchContextUsage = useCallback(async (kinId: string) => {
     try {
-      const data = await api.get<{ contextTokens: number; contextWindow: number }>(`/kins/${kinId}/context-usage`)
+      const data = await api.get<{ contextTokens: number; contextWindow: number; compactingTokens?: number; compactingThreshold?: number; compactingMessages?: number; compactingMessageThreshold?: number }>(`/kins/${kinId}/context-usage`)
       setKinQueueState((prev) => {
         const existing = prev.get(kinId)
         // Don't overwrite if SSE already provided fresh data
@@ -221,6 +227,10 @@ export function useKins() {
           queueSize: existing?.queueSize ?? 0,
           contextTokens: data.contextTokens,
           contextWindow: data.contextWindow,
+          compactingTokens: data.compactingTokens,
+          compactingThreshold: data.compactingThreshold,
+          compactingMessages: data.compactingMessages,
+          compactingMessageThreshold: data.compactingMessageThreshold,
         })
         return next
       })

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -336,6 +336,16 @@
       "character": "You are a friendly, thoughtful, and versatile assistant. You communicate clearly and adapt your tone to the context - casual when appropriate, precise when needed.\n\nYou are patient, curious, and genuinely enjoy helping. When you don't know something, you say so honestly. You ask clarifying questions when the request is ambiguous.\n\nYou keep your responses concise unless the user explicitly asks for detail.",
       "expertise": "You have broad general knowledge and can help with a wide range of topics:\n- Writing, editing, and summarizing text\n- Research, analysis, and problem-solving\n- Brainstorming and creative tasks\n- Explaining complex concepts simply\n- Planning and organizing\n\nYou adapt your level of detail and technicality based on what the user needs."
     },
+    "compacting": {
+      "title": "Compacting thresholds",
+      "overrideHint": "Leave empty to use the global defaults. Only fill in to override for this Kin.",
+      "messageThreshold": "Message threshold",
+      "tokenThreshold": "Token threshold",
+      "messageThresholdPlaceholder": "Default: {{default}}",
+      "tokenThresholdPlaceholder": "Default: {{default}}",
+      "messageThresholdHint": "Global default: {{default}}",
+      "tokenThresholdHint": "Global default: {{default}}"
+    },
     "avatar": {
       "title": "Choose avatar",
       "upload": "Upload",
@@ -459,6 +469,10 @@
     "contextUsage": "Context: ~{{tokens}} / {{max}} tokens ({{percent}}%), includes system prompt, history & tools",
     "contextNoData": "Context usage will appear after the first message is processed",
     "forceCompact": "Force compaction",
+    "tooltipContext": "Context window",
+    "tooltipCompacting": "Compaction",
+    "compactingProximity": "Compaction in ~{{tokens}} tokens ({{messages}}/{{maxMessages}} msgs)",
+    "compactingMarker": "Compaction threshold",
     "moreActions": "More actions",
     "compacting": {
       "title": "Compacting conversation",

--- a/src/client/locales/fr.json
+++ b/src/client/locales/fr.json
@@ -336,6 +336,16 @@
       "character": "Tu es un assistant amical, réfléchi et polyvalent. Tu communiques clairement et tu adaptes ton ton au contexte - décontracté quand c'est approprié, précis quand c'est nécessaire.\n\nTu es patient, curieux et tu prends plaisir à aider. Quand tu ne sais pas quelque chose, tu le dis honnêtement. Tu poses des questions de clarification quand la demande est ambiguë.\n\nTu gardes tes réponses concises sauf si l'utilisateur demande explicitement plus de détails.",
       "expertise": "Tu as des connaissances générales étendues et tu peux aider sur un large éventail de sujets :\n- Rédaction, édition et synthèse de texte\n- Recherche, analyse et résolution de problèmes\n- Brainstorming et tâches créatives\n- Explication de concepts complexes de manière simple\n- Planification et organisation\n\nTu adaptes ton niveau de détail et de technicité en fonction des besoins de l'utilisateur."
     },
+    "compacting": {
+      "title": "Seuils de compaction",
+      "overrideHint": "Laisser vide pour utiliser les défauts globaux. Remplir uniquement pour personnaliser ce Kin.",
+      "messageThreshold": "Seuil de messages",
+      "tokenThreshold": "Seuil de tokens",
+      "messageThresholdPlaceholder": "Défaut : {{default}}",
+      "tokenThresholdPlaceholder": "Défaut : {{default}}",
+      "messageThresholdHint": "Défaut global : {{default}}",
+      "tokenThresholdHint": "Défaut global : {{default}}"
+    },
     "avatar": {
       "title": "Choisir l'avatar",
       "upload": "Importer",
@@ -459,6 +469,10 @@
     "contextUsage": "Contexte : ~{{tokens}} / {{max}} tokens ({{percent}} %), inclut prompt système, historique et outils",
     "contextNoData": "L'utilisation du contexte apparaîtra après le premier message traité",
     "forceCompact": "Forcer la compaction",
+    "tooltipContext": "Fenêtre de contexte",
+    "tooltipCompacting": "Compaction",
+    "compactingProximity": "Compaction dans ~{{tokens}} tokens ({{messages}}/{{maxMessages}} msgs)",
+    "compactingMarker": "Seuil de compaction",
     "moreActions": "Plus d'actions",
     "compacting": {
       "title": "Compaction de la conversation",

--- a/src/server/db/migrations/0039_damp_drax.sql
+++ b/src/server/db/migrations/0039_damp_drax.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `kins` ADD `compacting_config` text;

--- a/src/server/db/migrations/meta/0039_snapshot.json
+++ b/src/server/db/migrations/meta/0039_snapshot.json
@@ -1,0 +1,4939 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "a6484ea4-f735-424f-add8-0e32378293d1",
+  "prevId": "493d766f-f5e9-425f-9de8-a46f49157bf0",
+  "tables": {
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_message_links": {
+      "name": "channel_message_links",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_message_id": {
+          "name": "platform_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_chat_id": {
+          "name": "platform_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_cml_message": {
+          "name": "idx_cml_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        },
+        "idx_cml_channel": {
+          "name": "idx_cml_channel",
+          "columns": [
+            "channel_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_message_links_channel_id_channels_id_fk": {
+          "name": "channel_message_links_channel_id_channels_id_fk",
+          "tableFrom": "channel_message_links",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_message_links_message_id_messages_id_fk": {
+          "name": "channel_message_links_message_id_messages_id_fk",
+          "tableFrom": "channel_message_links",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channel_user_mappings": {
+      "name": "channel_user_mappings",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_username": {
+          "name": "platform_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "platform_display_name": {
+          "name": "platform_display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'approved'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_channel_user_map": {
+          "name": "idx_channel_user_map",
+          "columns": [
+            "channel_id",
+            "platform_user_id"
+          ],
+          "isUnique": true
+        },
+        "idx_channel_user_map_status": {
+          "name": "idx_channel_user_map_status",
+          "columns": [
+            "channel_id",
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channel_user_mappings_channel_id_channels_id_fk": {
+          "name": "channel_user_mappings_channel_id_channels_id_fk",
+          "tableFrom": "channel_user_mappings",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "channel_user_mappings_contact_id_contacts_id_fk": {
+          "name": "channel_user_mappings_contact_id_contacts_id_fk",
+          "tableFrom": "channel_user_mappings",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "channels": {
+      "name": "channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_config": {
+          "name": "platform_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'inactive'"
+        },
+        "status_message": {
+          "name": "status_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_create_contacts": {
+          "name": "auto_create_contacts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "messages_received": {
+          "name": "messages_received",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "messages_sent": {
+          "name": "messages_sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_activity_at": {
+          "name": "last_activity_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'user'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_channels_kin_id": {
+          "name": "idx_channels_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "channels_kin_id_kins_id_fk": {
+          "name": "channels_kin_id_kins_id_fk",
+          "tableFrom": "channels",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "compacting_snapshots": {
+      "name": "compacting_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "messages_up_to_id": {
+          "name": "messages_up_to_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_compacting_kin_active": {
+          "name": "idx_compacting_kin_active",
+          "columns": [
+            "kin_id",
+            "is_active"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "compacting_snapshots_kin_id_kins_id_fk": {
+          "name": "compacting_snapshots_kin_id_kins_id_fk",
+          "tableFrom": "compacting_snapshots",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "compacting_snapshots_messages_up_to_id_messages_id_fk": {
+          "name": "compacting_snapshots_messages_up_to_id_messages_id_fk",
+          "tableFrom": "compacting_snapshots",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "messages_up_to_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_identifiers": {
+      "name": "contact_identifiers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_contact_identifiers_contact_id": {
+          "name": "idx_contact_identifiers_contact_id",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_identifiers_contact_id_contacts_id_fk": {
+          "name": "contact_identifiers_contact_id_contacts_id_fk",
+          "tableFrom": "contact_identifiers",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_notes": {
+      "name": "contact_notes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_contact_notes_unique": {
+          "name": "idx_contact_notes_unique",
+          "columns": [
+            "contact_id",
+            "kin_id",
+            "scope"
+          ],
+          "isUnique": true
+        },
+        "idx_contact_notes_contact_id": {
+          "name": "idx_contact_notes_contact_id",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        },
+        "idx_contact_notes_kin_id": {
+          "name": "idx_contact_notes_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_notes_contact_id_contacts_id_fk": {
+          "name": "contact_notes_contact_id_contacts_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "contact_notes_kin_id_kins_id_fk": {
+          "name": "contact_notes_kin_id_kins_id_fk",
+          "tableFrom": "contact_notes",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contact_platform_ids": {
+      "name": "contact_platform_ids",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_id": {
+          "name": "platform_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_contact_platform_ids_unique": {
+          "name": "idx_contact_platform_ids_unique",
+          "columns": [
+            "platform",
+            "platform_id"
+          ],
+          "isUnique": true
+        },
+        "idx_contact_platform_ids_contact": {
+          "name": "idx_contact_platform_ids_contact",
+          "columns": [
+            "contact_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "contact_platform_ids_contact_id_contacts_id_fk": {
+          "name": "contact_platform_ids_contact_id_contacts_id_fk",
+          "tableFrom": "contact_platform_ids",
+          "tableTo": "contacts",
+          "columnsFrom": [
+            "contact_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "contacts": {
+      "name": "contacts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "linked_user_id": {
+          "name": "linked_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linked_kin_id": {
+          "name": "linked_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "contacts_linked_user_id_user_id_fk": {
+          "name": "contacts_linked_user_id_user_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "user",
+          "columnsFrom": [
+            "linked_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "contacts_linked_kin_id_kins_id_fk": {
+          "name": "contacts_linked_kin_id_kins_id_fk",
+          "tableFrom": "contacts",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "linked_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "crons": {
+      "name": "crons",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_description": {
+          "name": "task_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kin_id": {
+          "name": "target_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "requires_approval": {
+          "name": "requires_approval",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "run_once": {
+          "name": "run_once",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "crons_kin_id_kins_id_fk": {
+          "name": "crons_kin_id_kins_id_fk",
+          "tableFrom": "crons",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "crons_target_kin_id_kins_id_fk": {
+          "name": "crons_target_kin_id_kins_id_fk",
+          "tableFrom": "crons",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "target_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "custom_tools": {
+      "name": "custom_tools",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parameters": {
+          "name": "parameters",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "script_path": {
+          "name": "script_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_custom_tools_kin_name": {
+          "name": "idx_custom_tools_kin_name",
+          "columns": [
+            "kin_id",
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "custom_tools_kin_id_kins_id_fk": {
+          "name": "custom_tools_kin_id_kins_id_fk",
+          "tableFrom": "custom_tools",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "file_storage": {
+      "name": "file_storage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stored_path": {
+          "name": "stored_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "read_and_burn": {
+          "name": "read_and_burn",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "download_count": {
+          "name": "download_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_by_kin_id": {
+          "name": "created_by_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "file_storage_access_token_unique": {
+          "name": "file_storage_access_token_unique",
+          "columns": [
+            "access_token"
+          ],
+          "isUnique": true
+        },
+        "idx_file_storage_token": {
+          "name": "idx_file_storage_token",
+          "columns": [
+            "access_token"
+          ],
+          "isUnique": false
+        },
+        "idx_file_storage_kin": {
+          "name": "idx_file_storage_kin",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        },
+        "idx_file_storage_expires": {
+          "name": "idx_file_storage_expires",
+          "columns": [
+            "expires_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "file_storage_kin_id_kins_id_fk": {
+          "name": "file_storage_kin_id_kins_id_fk",
+          "tableFrom": "file_storage",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "file_storage_created_by_kin_id_kins_id_fk": {
+          "name": "file_storage_created_by_kin_id_kins_id_fk",
+          "tableFrom": "file_storage",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "created_by_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "files": {
+      "name": "files",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uploaded_by": {
+          "name": "uploaded_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stored_path": {
+          "name": "stored_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "files_kin_id_kins_id_fk": {
+          "name": "files_kin_id_kins_id_fk",
+          "tableFrom": "files",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_message_id_messages_id_fk": {
+          "name": "files_message_id_messages_id_fk",
+          "tableFrom": "files",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "files_uploaded_by_user_id_fk": {
+          "name": "files_uploaded_by_user_id_fk",
+          "tableFrom": "files",
+          "tableTo": "user",
+          "columnsFrom": [
+            "uploaded_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "human_prompts": {
+      "name": "human_prompts",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_type": {
+          "name": "prompt_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "options": {
+          "name": "options",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "response": {
+          "name": "response",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responded_at": {
+          "name": "responded_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_human_prompts_kin": {
+          "name": "idx_human_prompts_kin",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        },
+        "idx_human_prompts_task": {
+          "name": "idx_human_prompts_task",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "idx_human_prompts_status": {
+          "name": "idx_human_prompts_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "human_prompts_kin_id_kins_id_fk": {
+          "name": "human_prompts_kin_id_kins_id_fk",
+          "tableFrom": "human_prompts",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "human_prompts_task_id_tasks_id_fk": {
+          "name": "human_prompts_task_id_tasks_id_fk",
+          "tableFrom": "human_prompts",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "human_prompts_message_id_messages_id_fk": {
+          "name": "human_prompts_message_id_messages_id_fk",
+          "tableFrom": "human_prompts",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "invitations": {
+      "name": "invitations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "used_by": {
+          "name": "used_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "invitations_token_unique": {
+          "name": "invitations_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_invitations_created_by": {
+          "name": "idx_invitations_created_by",
+          "columns": [
+            "created_by"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "invitations_created_by_user_id_fk": {
+          "name": "invitations_created_by_user_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "invitations_kin_id_kins_id_fk": {
+          "name": "invitations_kin_id_kins_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "invitations_used_by_user_id_fk": {
+          "name": "invitations_used_by_user_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "user",
+          "columnsFrom": [
+            "used_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kin_mcp_servers": {
+      "name": "kin_mcp_servers",
+      "columns": {
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mcp_server_id": {
+          "name": "mcp_server_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "kin_mcp_servers_kin_id_kins_id_fk": {
+          "name": "kin_mcp_servers_kin_id_kins_id_fk",
+          "tableFrom": "kin_mcp_servers",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "kin_mcp_servers_mcp_server_id_mcp_servers_id_fk": {
+          "name": "kin_mcp_servers_mcp_server_id_mcp_servers_id_fk",
+          "tableFrom": "kin_mcp_servers",
+          "tableTo": "mcp_servers",
+          "columnsFrom": [
+            "mcp_server_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "kin_mcp_servers_kin_id_mcp_server_id_pk": {
+          "columns": [
+            "kin_id",
+            "mcp_server_id"
+          ],
+          "name": "kin_mcp_servers_kin_id_mcp_server_id_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "kins": {
+      "name": "kins",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avatar_path": {
+          "name": "avatar_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "character": {
+          "name": "character",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expertise": {
+          "name": "expertise",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_path": {
+          "name": "workspace_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tool_config": {
+          "name": "tool_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "compacting_config": {
+          "name": "compacting_config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "kins_slug_unique": {
+          "name": "kins_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "kins_provider_id_providers_id_fk": {
+          "name": "kins_provider_id_providers_id_fk",
+          "tableFrom": "kins",
+          "tableTo": "providers",
+          "columnsFrom": [
+            "provider_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "kins_created_by_user_id_fk": {
+          "name": "kins_created_by_user_id_fk",
+          "tableFrom": "kins",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_chunks": {
+      "name": "knowledge_chunks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_knowledge_chunks_kin_id": {
+          "name": "idx_knowledge_chunks_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        },
+        "idx_knowledge_chunks_source_id": {
+          "name": "idx_knowledge_chunks_source_id",
+          "columns": [
+            "source_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "knowledge_chunks_source_id_knowledge_sources_id_fk": {
+          "name": "knowledge_chunks_source_id_knowledge_sources_id_fk",
+          "tableFrom": "knowledge_chunks",
+          "tableTo": "knowledge_sources",
+          "columnsFrom": [
+            "source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "knowledge_chunks_kin_id_kins_id_fk": {
+          "name": "knowledge_chunks_kin_id_kins_id_fk",
+          "tableFrom": "knowledge_chunks",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "knowledge_sources": {
+      "name": "knowledge_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "stored_path": {
+          "name": "stored_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_url": {
+          "name": "source_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "raw_content": {
+          "name": "raw_content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "chunk_count": {
+          "name": "chunk_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "token_count": {
+          "name": "token_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_knowledge_sources_kin_id": {
+          "name": "idx_knowledge_sources_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "knowledge_sources_kin_id_kins_id_fk": {
+          "name": "knowledge_sources_kin_id_kins_id_fk",
+          "tableFrom": "knowledge_sources",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mcp_servers": {
+      "name": "mcp_servers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "command": {
+          "name": "command",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "args": {
+          "name": "args",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "env": {
+          "name": "env",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_by_kin_id": {
+          "name": "created_by_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mcp_servers_created_by_kin_id_kins_id_fk": {
+          "name": "mcp_servers_created_by_kin_id_kins_id_fk",
+          "tableFrom": "mcp_servers",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "created_by_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "memories": {
+      "name": "memories",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "embedding": {
+          "name": "embedding",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "subject": {
+          "name": "subject",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_message_id": {
+          "name": "source_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_channel": {
+          "name": "source_channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'automatic'"
+        },
+        "importance": {
+          "name": "importance",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retrieval_count": {
+          "name": "retrieval_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_retrieved_at": {
+          "name": "last_retrieved_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consolidation_generation": {
+          "name": "consolidation_generation",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "consolidated_from_ids": {
+          "name": "consolidated_from_ids",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_memories_kin_id": {
+          "name": "idx_memories_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        },
+        "idx_memories_kin_category": {
+          "name": "idx_memories_kin_category",
+          "columns": [
+            "kin_id",
+            "category"
+          ],
+          "isUnique": false
+        },
+        "idx_memories_kin_subject": {
+          "name": "idx_memories_kin_subject",
+          "columns": [
+            "kin_id",
+            "subject"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "memories_kin_id_kins_id_fk": {
+          "name": "memories_kin_id_kins_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "memories_source_message_id_messages_id_fk": {
+          "name": "memories_source_message_id_messages_id_fk",
+          "tableFrom": "memories",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "source_message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "message_reactions": {
+      "name": "message_reactions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_message_reactions_unique": {
+          "name": "idx_message_reactions_unique",
+          "columns": [
+            "message_id",
+            "user_id",
+            "emoji"
+          ],
+          "isUnique": true
+        },
+        "idx_message_reactions_message": {
+          "name": "idx_message_reactions_message",
+          "columns": [
+            "message_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "message_reactions_message_id_messages_id_fk": {
+          "name": "message_reactions_message_id_messages_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "messages",
+          "columnsFrom": [
+            "message_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "message_reactions_user_id_user_id_fk": {
+          "name": "message_reactions_user_id_user_id_fk",
+          "tableFrom": "message_reactions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_calls": {
+          "name": "tool_calls",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "tool_call_id": {
+          "name": "tool_call_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_redacted": {
+          "name": "is_redacted",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "redact_pending": {
+          "name": "redact_pending",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_messages_kin_id": {
+          "name": "idx_messages_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_task_id": {
+          "name": "idx_messages_task_id",
+          "columns": [
+            "task_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_kin_created": {
+          "name": "idx_messages_kin_created",
+          "columns": [
+            "kin_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_source": {
+          "name": "idx_messages_source",
+          "columns": [
+            "source_type",
+            "source_id"
+          ],
+          "isUnique": false
+        },
+        "idx_messages_session_id": {
+          "name": "idx_messages_session_id",
+          "columns": [
+            "session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_kin_id_kins_id_fk": {
+          "name": "messages_kin_id_kins_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messages_task_id_tasks_id_fk": {
+          "name": "messages_task_id_tasks_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "messages_session_id_quick_sessions_id_fk": {
+          "name": "messages_session_id_quick_sessions_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "quick_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mini_app_snapshots": {
+      "name": "mini_app_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "file_manifest": {
+          "name": "file_manifest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mini_app_snapshots_app_id": {
+          "name": "idx_mini_app_snapshots_app_id",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        },
+        "idx_mini_app_snapshots_app_version": {
+          "name": "idx_mini_app_snapshots_app_version",
+          "columns": [
+            "app_id",
+            "version"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mini_app_snapshots_app_id_mini_apps_id_fk": {
+          "name": "mini_app_snapshots_app_id_mini_apps_id_fk",
+          "tableFrom": "mini_app_snapshots",
+          "tableTo": "mini_apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mini_app_storage": {
+      "name": "mini_app_storage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mini_app_storage_app_key": {
+          "name": "idx_mini_app_storage_app_key",
+          "columns": [
+            "app_id",
+            "key"
+          ],
+          "isUnique": true
+        },
+        "idx_mini_app_storage_app_id": {
+          "name": "idx_mini_app_storage_app_id",
+          "columns": [
+            "app_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mini_app_storage_app_id_mini_apps_id_fk": {
+          "name": "mini_app_storage_app_id_mini_apps_id_fk",
+          "tableFrom": "mini_app_storage",
+          "tableTo": "mini_apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mini_apps": {
+      "name": "mini_apps",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_file": {
+          "name": "entry_file",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'index.html'"
+        },
+        "has_backend": {
+          "name": "has_backend",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_mini_apps_kin_slug": {
+          "name": "idx_mini_apps_kin_slug",
+          "columns": [
+            "kin_id",
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "idx_mini_apps_kin_id": {
+          "name": "idx_mini_apps_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "mini_apps_kin_id_kins_id_fk": {
+          "name": "mini_apps_kin_id_kins_id_fk",
+          "tableFrom": "mini_apps",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_channels": {
+      "name": "notification_channels",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "platform_chat_id": {
+          "name": "platform_chat_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "label": {
+          "name": "label",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "type_filter": {
+          "name": "type_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_delivered_at": {
+          "name": "last_delivered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "consecutive_errors": {
+          "name": "consecutive_errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notif_channels_user": {
+          "name": "idx_notif_channels_user",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "idx_notif_channels_unique": {
+          "name": "idx_notif_channels_unique",
+          "columns": [
+            "user_id",
+            "channel_id",
+            "platform_chat_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "notification_channels_user_id_user_id_fk": {
+          "name": "notification_channels_user_id_user_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_channels_channel_id_channels_id_fk": {
+          "name": "notification_channels_channel_id_channels_id_fk",
+          "tableFrom": "notification_channels",
+          "tableTo": "channels",
+          "columnsFrom": [
+            "channel_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notification_preferences": {
+      "name": "notification_preferences",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        }
+      },
+      "indexes": {
+        "idx_notif_pref_user_type": {
+          "name": "idx_notif_pref_user_type",
+          "columns": [
+            "user_id",
+            "type"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "notification_preferences_user_id_user_id_fk": {
+          "name": "notification_preferences_user_id_user_id_fk",
+          "tableFrom": "notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "notifications": {
+      "name": "notifications",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_id": {
+          "name": "related_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "related_type": {
+          "name": "related_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_read": {
+          "name": "is_read",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_notifications_user_read": {
+          "name": "idx_notifications_user_read",
+          "columns": [
+            "user_id",
+            "is_read",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "idx_notifications_user_created": {
+          "name": "idx_notifications_user_created",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_user_id_fk": {
+          "name": "notifications_user_id_user_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notifications_kin_id_kins_id_fk": {
+          "name": "notifications_kin_id_kins_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_states": {
+      "name": "plugin_states",
+      "columns": {
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "approved_permissions": {
+          "name": "approved_permissions",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_source": {
+          "name": "install_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "install_meta": {
+          "name": "install_meta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "plugin_storage": {
+      "name": "plugin_storage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "plugin_name": {
+          "name": "plugin_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_plugin_storage_name_key": {
+          "name": "idx_plugin_storage_name_key",
+          "columns": [
+            "plugin_name",
+            "key"
+          ],
+          "isUnique": true
+        },
+        "idx_plugin_storage_plugin": {
+          "name": "idx_plugin_storage_plugin",
+          "columns": [
+            "plugin_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "providers": {
+      "name": "providers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config_encrypted": {
+          "name": "config_encrypted",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "capabilities": {
+          "name": "capabilities",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_valid": {
+          "name": "is_valid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "queue_items": {
+      "name": "queue_items",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message_type": {
+          "name": "message_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "request_id": {
+          "name": "request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "in_reply_to": {
+          "name": "in_reply_to",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_queue_kin_status_priority": {
+          "name": "idx_queue_kin_status_priority",
+          "columns": [
+            "kin_id",
+            "status",
+            "priority",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "queue_items_kin_id_kins_id_fk": {
+          "name": "queue_items_kin_id_kins_id_fk",
+          "tableFrom": "queue_items",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "queue_items_task_id_tasks_id_fk": {
+          "name": "queue_items_task_id_tasks_id_fk",
+          "tableFrom": "queue_items",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quick_sessions": {
+      "name": "quick_sessions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "closed_at": {
+          "name": "closed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_quick_sessions_kin_status": {
+          "name": "idx_quick_sessions_kin_status",
+          "columns": [
+            "kin_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_quick_sessions_user": {
+          "name": "idx_quick_sessions_user",
+          "columns": [
+            "created_by"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "quick_sessions_kin_id_kins_id_fk": {
+          "name": "quick_sessions_kin_id_kins_id_fk",
+          "tableFrom": "quick_sessions",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "quick_sessions_created_by_user_id_fk": {
+          "name": "quick_sessions_created_by_user_id_fk",
+          "tableFrom": "quick_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "scheduled_wakeups": {
+      "name": "scheduled_wakeups",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "caller_kin_id": {
+          "name": "caller_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_kin_id": {
+          "name": "target_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fire_at": {
+          "name": "fire_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "interval_seconds": {
+          "name": "interval_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_wakeups_target_status": {
+          "name": "idx_wakeups_target_status",
+          "columns": [
+            "target_kin_id",
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_wakeups_caller": {
+          "name": "idx_wakeups_caller",
+          "columns": [
+            "caller_kin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "scheduled_wakeups_caller_kin_id_kins_id_fk": {
+          "name": "scheduled_wakeups_caller_kin_id_kins_id_fk",
+          "tableFrom": "scheduled_wakeups",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "caller_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "scheduled_wakeups_target_kin_id_kins_id_fk": {
+          "name": "scheduled_wakeups_target_kin_id_kins_id_fk",
+          "tableFrom": "scheduled_wakeups",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "target_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_kin_id": {
+          "name": "parent_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_kin_id": {
+          "name": "source_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "spawn_type": {
+          "name": "spawn_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'await'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'pending'"
+        },
+        "result": {
+          "name": "result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "depth": {
+          "name": "depth",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "parent_task_id": {
+          "name": "parent_task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cron_id": {
+          "name": "cron_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "request_input_count": {
+          "name": "request_input_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "allow_human_prompt": {
+          "name": "allow_human_prompt",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_tasks_parent_kin": {
+          "name": "idx_tasks_parent_kin",
+          "columns": [
+            "parent_kin_id"
+          ],
+          "isUnique": false
+        },
+        "idx_tasks_status": {
+          "name": "idx_tasks_status",
+          "columns": [
+            "status"
+          ],
+          "isUnique": false
+        },
+        "idx_tasks_cron": {
+          "name": "idx_tasks_cron",
+          "columns": [
+            "cron_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_parent_kin_id_kins_id_fk": {
+          "name": "tasks_parent_kin_id_kins_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "parent_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_source_kin_id_kins_id_fk": {
+          "name": "tasks_source_kin_id_kins_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "source_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_parent_task_id_tasks_id_fk": {
+          "name": "tasks_parent_task_id_tasks_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "tasks",
+          "columnsFrom": [
+            "parent_task_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "tasks_cron_id_crons_id_fk": {
+          "name": "tasks_cron_id_crons_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "crons",
+          "columnsFrom": [
+            "cron_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user_profiles": {
+      "name": "user_profiles",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pseudonym": {
+          "name": "pseudonym",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language": {
+          "name": "language",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'fr'"
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'member'"
+        },
+        "kin_order": {
+          "name": "kin_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cron_order": {
+          "name": "cron_order",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_profiles_user_id_user_id_fk": {
+          "name": "user_profiles_user_id_user_id_fk",
+          "tableFrom": "user_profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_attachments": {
+      "name": "vault_attachments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entry_id": {
+          "name": "entry_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "original_name": {
+          "name": "original_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "stored_path": {
+          "name": "stored_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "size": {
+          "name": "size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_vault_attachments_entry": {
+          "name": "idx_vault_attachments_entry",
+          "columns": [
+            "entry_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "vault_attachments_entry_id_vault_secrets_id_fk": {
+          "name": "vault_attachments_entry_id_vault_secrets_id_fk",
+          "tableFrom": "vault_attachments",
+          "tableTo": "vault_secrets",
+          "columnsFrom": [
+            "entry_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_secrets": {
+      "name": "vault_secrets",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "entry_type": {
+          "name": "entry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'text'"
+        },
+        "vault_type_id": {
+          "name": "vault_type_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_favorite": {
+          "name": "is_favorite",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by_kin_id": {
+          "name": "created_by_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "vault_secrets_key_unique": {
+          "name": "vault_secrets_key_unique",
+          "columns": [
+            "key"
+          ],
+          "isUnique": true
+        },
+        "idx_vault_secrets_entry_type": {
+          "name": "idx_vault_secrets_entry_type",
+          "columns": [
+            "entry_type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "vault_secrets_vault_type_id_vault_types_id_fk": {
+          "name": "vault_secrets_vault_type_id_vault_types_id_fk",
+          "tableFrom": "vault_secrets",
+          "tableTo": "vault_types",
+          "columnsFrom": [
+            "vault_type_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "vault_secrets_created_by_kin_id_kins_id_fk": {
+          "name": "vault_secrets_created_by_kin_id_kins_id_fk",
+          "tableFrom": "vault_secrets",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "created_by_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "vault_types": {
+      "name": "vault_types",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "icon": {
+          "name": "icon",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fields": {
+          "name": "fields",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_built_in": {
+          "name": "is_built_in",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_by_kin_id": {
+          "name": "created_by_kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "vault_types_slug_unique": {
+          "name": "vault_types_slug_unique",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "vault_types_created_by_kin_id_kins_id_fk": {
+          "name": "vault_types_created_by_kin_id_kins_id_fk",
+          "tableFrom": "vault_types",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "created_by_kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhook_logs": {
+      "name": "webhook_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "webhook_id": {
+          "name": "webhook_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_webhook_logs_webhook_created": {
+          "name": "idx_webhook_logs_webhook_created",
+          "columns": [
+            "webhook_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhook_logs_webhook_id_webhooks_id_fk": {
+          "name": "webhook_logs_webhook_id_webhooks_id_fk",
+          "tableFrom": "webhook_logs",
+          "tableTo": "webhooks",
+          "columnsFrom": [
+            "webhook_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "webhooks": {
+      "name": "webhooks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kin_id": {
+          "name": "kin_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": true
+        },
+        "last_triggered_at": {
+          "name": "last_triggered_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_count": {
+          "name": "trigger_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "webhooks_token_unique": {
+          "name": "webhooks_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "idx_webhooks_kin_id": {
+          "name": "idx_webhooks_kin_id",
+          "columns": [
+            "kin_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "webhooks_kin_id_kins_id_fk": {
+          "name": "webhooks_kin_id_kins_id_fk",
+          "tableFrom": "webhooks",
+          "tableTo": "kins",
+          "columnsFrom": [
+            "kin_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src/server/db/migrations/meta/_journal.json
+++ b/src/server/db/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1772929760011,
       "tag": "0038_empty_quasimodo",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1772992609652,
+      "tag": "0039_damp_drax",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -81,6 +81,7 @@ export const kins = sqliteTable('kins', {
   providerId: text('provider_id').references(() => providers.id, { onDelete: 'set null' }),
   workspacePath: text('workspace_path').notNull(),
   toolConfig: text('tool_config'), // JSON: KinToolConfig
+  compactingConfig: text('compacting_config'), // JSON: KinCompactingConfig
   createdBy: text('created_by').references(() => user.id),
   createdAt: integer('created_at', { mode: 'timestamp_ms' }).notNull(),
   updatedAt: integer('updated_at', { mode: 'timestamp_ms' }).notNull(),

--- a/src/server/routes/kins.ts
+++ b/src/server/routes/kins.ts
@@ -329,10 +329,21 @@ kinRoutes.get('/:id/context-usage', async (c) => {
     return c.json({ error: { code: 'KIN_NOT_FOUND', message: 'Kin not found' } }, 404)
   }
 
+  // Compute compacting proximity (always fresh)
+  const { getCompactingProximity } = await import('@/server/services/compacting')
+  const compacting = await getCompactingProximity(kin.id)
+
   // Use cached context usage from the last LLM call if available
   const cached = getLastContextUsage(kin.id)
   if (cached) {
-    return c.json({ contextTokens: cached.contextTokens, contextWindow: cached.contextWindow })
+    return c.json({
+      contextTokens: cached.contextTokens,
+      contextWindow: cached.contextWindow,
+      compactingTokens: compacting.currentTokens,
+      compactingThreshold: compacting.tokenThreshold,
+      compactingMessages: compacting.currentMessages,
+      compactingMessageThreshold: compacting.messageThreshold,
+    })
   }
 
   // Fallback: rough estimation for kins that haven't processed a message yet
@@ -376,7 +387,14 @@ kinRoutes.get('/:id/context-usage', async (c) => {
     if (msg.content) contextTokens += estimateTokens(msg.content)
   }
 
-  return c.json({ contextTokens, contextWindow })
+  return c.json({
+    contextTokens,
+    contextWindow,
+    compactingTokens: compacting.currentTokens,
+    compactingThreshold: compacting.tokenThreshold,
+    compactingMessages: compacting.currentMessages,
+    compactingMessageThreshold: compacting.messageThreshold,
+  })
 })
 
 // ─── Kin CRUD (parameterized routes) ───────────────────────────────────────
@@ -415,6 +433,7 @@ kinRoutes.get('/:id', async (c) => {
     providerId: details.providerId ?? null,
     workspacePath: details.workspacePath,
     toolConfig: details.toolConfig ? JSON.parse(details.toolConfig) : null,
+    compactingConfig: details.compactingConfig ? JSON.parse(details.compactingConfig) : null,
     mcpServers: details.mcpServers,
     queueSize,
     isProcessing,
@@ -507,6 +526,7 @@ kinRoutes.patch('/:id', async (c) => {
     providerId: body.providerId,
     slug: body.slug,
     toolConfig: body.toolConfig,
+    compactingConfig: body.compactingConfig,
     mcpServerIds: body.mcpServerIds,
   })
 
@@ -529,6 +549,7 @@ kinRoutes.patch('/:id', async (c) => {
       providerId: details.providerId ?? null,
       workspacePath: details.workspacePath,
       toolConfig: details.toolConfig ? JSON.parse(details.toolConfig) : null,
+      compactingConfig: details.compactingConfig ? JSON.parse(details.compactingConfig) : null,
       mcpServers: details.mcpServers,
       queueSize: 0,
       isProcessing: false,
@@ -975,6 +996,7 @@ kinRoutes.get('/:id/export', async (c) => {
     expertise: details.expertise,
     model: details.model,
     toolConfig: details.toolConfig ? JSON.parse(details.toolConfig) : null,
+    compactingConfig: details.compactingConfig ? JSON.parse(details.compactingConfig) : null,
     mcpServers: mcpServerDetails,
   }
 

--- a/src/server/services/compacting.ts
+++ b/src/server/services/compacting.ts
@@ -14,7 +14,7 @@ import { config } from '@/server/config'
 import { getExtractionModel } from '@/server/services/app-settings'
 import { createMemory, updateMemory, isDuplicateMemory } from '@/server/services/memory'
 import { sseManager } from '@/server/sse/index'
-import type { MemoryCategory } from '@/shared/types'
+import type { MemoryCategory, KinCompactingConfig } from '@/shared/types'
 
 const log = createLogger('compacting')
 
@@ -23,21 +23,36 @@ function estimateTokens(text: string): number {
   return Math.ceil(text.length / 4)
 }
 
-// ─── Threshold Evaluation ────────────────────────────────────────────────────
+// ─── Per-Kin Threshold Resolution ────────────────────────────────────────────
 
-/**
- * Evaluate whether compacting should trigger for a Kin.
- * Returns true if message count or token count exceeds thresholds.
- */
-async function shouldCompact(kinId: string): Promise<boolean> {
+/** Resolve effective compacting thresholds: per-Kin overrides > global defaults */
+async function getEffectiveThresholds(kinId: string): Promise<{ messageThreshold: number; tokenThreshold: number }> {
+  const kin = await db
+    .select({ compactingConfig: kins.compactingConfig })
+    .from(kins)
+    .where(eq(kins.id, kinId))
+    .get()
+
+  let kinConfig: KinCompactingConfig | null = null
+  if (kin?.compactingConfig) {
+    try { kinConfig = JSON.parse(kin.compactingConfig) as KinCompactingConfig } catch { /* use defaults */ }
+  }
+
+  return {
+    messageThreshold: kinConfig?.messageThreshold ?? config.compacting.messageThreshold,
+    tokenThreshold: kinConfig?.tokenThreshold ?? config.compacting.tokenThreshold,
+  }
+}
+
+/** Get non-compacted message stats for a Kin (shared by shouldCompact + getCompactingProximity) */
+async function getNonCompactedStats(kinId: string): Promise<{ currentTokens: number; currentMessages: number }> {
   const activeSnapshot = await db
     .select()
     .from(compactingSnapshots)
     .where(and(eq(compactingSnapshots.kinId, kinId), eq(compactingSnapshots.isActive, true)))
     .get()
 
-  // Get non-compacted messages (after snapshot, excluding redact_pending, quick sessions, and compacting traces)
-  let query = db
+  const allMessages = await db
     .select({ content: messages.content, createdAt: messages.createdAt })
     .from(messages)
     .where(
@@ -50,26 +65,60 @@ async function shouldCompact(kinId: string): Promise<boolean> {
       ),
     )
     .orderBy(asc(messages.createdAt))
-
-  const allMessages = await query.all()
+    .all()
 
   const nonCompacted = activeSnapshot
     ? allMessages.filter((m) => m.createdAt && activeSnapshot.createdAt && m.createdAt > activeSnapshot.createdAt)
     : allMessages
 
-  if (nonCompacted.length === 0) return false
-
-  // Check message count threshold
-  if (nonCompacted.length > config.compacting.messageThreshold) return true
-
-  // Check token threshold
-  const totalTokens = nonCompacted.reduce(
+  const currentTokens = nonCompacted.reduce(
     (sum, m) => sum + estimateTokens(m.content ?? ''),
     0,
   )
-  if (totalTokens > config.compacting.tokenThreshold) return true
 
+  return { currentTokens, currentMessages: nonCompacted.length }
+}
+
+// ─── Threshold Evaluation ────────────────────────────────────────────────────
+
+/**
+ * Evaluate whether compacting should trigger for a Kin.
+ * Returns true if message count or token count exceeds thresholds.
+ */
+async function shouldCompact(kinId: string): Promise<boolean> {
+  const [stats, thresholds] = await Promise.all([
+    getNonCompactedStats(kinId),
+    getEffectiveThresholds(kinId),
+  ])
+
+  if (stats.currentMessages === 0) return false
+  if (stats.currentMessages > thresholds.messageThreshold) return true
+  if (stats.currentTokens > thresholds.tokenThreshold) return true
   return false
+}
+
+// ─── Public: compacting proximity for UI ─────────────────────────────────────
+
+export interface CompactingProximity {
+  currentTokens: number
+  tokenThreshold: number
+  currentMessages: number
+  messageThreshold: number
+}
+
+/** Get compacting proximity data for display in the chat UI */
+export async function getCompactingProximity(kinId: string): Promise<CompactingProximity> {
+  const [stats, thresholds] = await Promise.all([
+    getNonCompactedStats(kinId),
+    getEffectiveThresholds(kinId),
+  ])
+
+  return {
+    currentTokens: stats.currentTokens,
+    tokenThreshold: thresholds.tokenThreshold,
+    currentMessages: stats.currentMessages,
+    messageThreshold: thresholds.messageThreshold,
+  }
 }
 
 // ─── Core Compacting ─────────────────────────────────────────────────────────

--- a/src/server/services/kin-engine.ts
+++ b/src/server/services/kin-engine.ts
@@ -70,6 +70,9 @@ export function getLastContextUsage(kinId: string) {
   return lastContextUsage.get(kinId) ?? null
 }
 
+// Cache of last computed compacting proximity per Kin
+const lastCompactingProximity = new Map<string, { compactingTokens: number; compactingThreshold: number; compactingMessages: number; compactingMessageThreshold: number }>()
+
 /**
  * Extract a human-readable message from a raw API error object.
  * Handles nested structures like { error: { message: "..." } } from Anthropic/OpenAI.
@@ -469,12 +472,25 @@ export async function processNextMessage(kinId: string): Promise<boolean> {
     setLastContextUsage(kinId, contextTokens, contextWindow)
     log.debug({ kinId, toolCount: Object.keys(tools).length, modelId: kin.model, contextTokens, contextWindow }, 'Starting LLM stream')
 
+    // Compute compacting proximity and cache it for lightweight SSE events
+    const { getCompactingProximity } = await import('@/server/services/compacting')
+    const compactingData = await getCompactingProximity(kinId)
+    lastCompactingProximity.set(kinId, {
+      compactingTokens: compactingData.currentTokens,
+      compactingThreshold: compactingData.tokenThreshold,
+      compactingMessages: compactingData.currentMessages,
+      compactingMessageThreshold: compactingData.messageThreshold,
+    })
+
     // Update the queue event with real context usage (the initial queue:update
     // was sent before system prompt/tools were built — now we have the full picture)
     sseManager.sendToKin(kinId, {
       type: 'queue:update',
       kinId,
-      data: { kinId, queueSize: 0, isProcessing: true, contextTokens, contextWindow },
+      data: {
+        kinId, queueSize: 0, isProcessing: true, contextTokens, contextWindow,
+        ...lastCompactingProximity.get(kinId),
+      },
     })
 
     // Send typing indicator on the channel when LLM processing starts (fire-and-forget)

--- a/src/server/services/kins.ts
+++ b/src/server/services/kins.ts
@@ -37,7 +37,7 @@ import { getHubKinId, setHubKinId } from '@/server/services/app-settings'
 import { createLogger } from '@/server/logger'
 import { deleteChannel } from '@/server/services/channels'
 import { stopJob } from '@/server/services/crons'
-import type { KinToolConfig } from '@/shared/types'
+import type { KinToolConfig, KinCompactingConfig } from '@/shared/types'
 
 const log = createLogger('services:kins')
 
@@ -64,6 +64,7 @@ export interface UpdateKinInput {
   providerId?: string | null
   slug?: string
   toolConfig?: KinToolConfig | null
+  compactingConfig?: KinCompactingConfig | null
   mcpServerIds?: string[]
 }
 
@@ -228,6 +229,7 @@ export async function updateKin(
   if (input.model !== undefined) updates.model = input.model
   if (input.providerId !== undefined) updates.providerId = input.providerId
   if (input.toolConfig !== undefined) updates.toolConfig = JSON.stringify(input.toolConfig)
+  if (input.compactingConfig !== undefined) updates.compactingConfig = input.compactingConfig ? JSON.stringify(input.compactingConfig) : null
 
   // Handle slug update
   if (input.slug !== undefined) {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -128,6 +128,14 @@ export interface KinToolConfig {
   searchProviderId?: string
 }
 
+/** Per-Kin compacting configuration (stored as JSON in kins.compacting_config) */
+export interface KinCompactingConfig {
+  /** Message count threshold before compacting triggers (null = use global default) */
+  messageThreshold?: number | null
+  /** Token count threshold before compacting triggers (null = use global default) */
+  tokenThreshold?: number | null
+}
+
 /** Task summary as returned by GET /api/tasks */
 export interface TaskSummary {
   id: string


### PR DESCRIPTION
## Summary

- **Per-Kin compacting thresholds**: each Kin can override the global `messageThreshold` and `tokenThreshold` via a new `compacting_config` JSON column
- **Compaction proximity in chat UI**: the header shows how close the conversation is to triggering compaction — text indicator, threshold marker on the context bar, and a rich tooltip with dedicated compaction progress bar
- **Settings in Memory tab**: empty inputs = use global defaults, fill in to override for this Kin

## Changes

**Backend** (5 files):
- `KinCompactingConfig` type in `shared/types.ts`
- `compacting_config` column + migration on `kins` table
- Refactored `compacting.ts`: `getEffectiveThresholds()`, `getNonCompactedStats()`, `getCompactingProximity()`
- `context-usage` endpoint + `queue:update` SSE carry compacting proximity data
- Kin CRUD accepts/returns `compactingConfig`

**Frontend** (7 files):
- `useKins` state extended with compacting fields
- `ConversationHeader`: text label, threshold marker on progress bar, rich tooltip with 2 sections (context + compaction)
- `KinFormModal`: compacting threshold inputs in Memory tab
- i18n en/fr

## Test plan

- [ ] Open a chat → compaction text + marker visible in header
- [ ] Hover the context bar → rich tooltip shows context window + compaction sections
- [ ] Send messages → compaction % increases
- [ ] Edit Kin → Memory tab → set custom thresholds → save → verify marker/text updates
- [ ] Clear custom thresholds → verify it falls back to global defaults
- [ ] Force compact → verify counters reset

🤖 Generated with [Claude Code](https://claude.com/claude-code)