### PR TITLE
fix: prevent duplicate tool calls in TaskDetailModal (fixes #233)

### DIFF
--- a/src/client/components/sidebar/TaskDetailModal.tsx
+++ b/src/client/components/sidebar/TaskDetailModal.tsx
@@ -100,12 +100,16 @@ export function TaskDetailModal({
   // Filter out messages already represented elsewhere in the modal:
   // - sourceType 'system' + role 'user' = instruction (shown in header)
   // - sourceType 'task' = report to parent (shown in result block at bottom)
+  // - message with same id as the current streaming message (polling can
+  //   fetch the persisted version while streaming is still active, causing
+  //   the same message to appear both in the list and as the streaming bubble)
   const visibleMessages = useMemo(
     () => messages.filter((msg) =>
       !(msg.sourceType === 'system' && msg.role === 'user') &&
-      msg.sourceType !== 'task'
+      msg.sourceType !== 'task' &&
+      !(streamingMessage && msg.id === streamingMessage.id)
     ),
-    [messages],
+    [messages, streamingMessage],
   )
 
   // Auto-scroll when messages or streaming update

--- a/src/client/hooks/useTaskDetail.ts
+++ b/src/client/hooks/useTaskDetail.ts
@@ -353,10 +353,15 @@ export function useTaskDetail(taskId: string | null) {
     return items
   }, [messages])
 
-  // Merge historical + streaming tool calls
+  // Merge historical + streaming tool calls (deduplicate by id — the 3s
+  // polling fallback can fetch persisted messages while the stream is still
+  // active, causing the same tool call to appear in both lists).
   const allToolCalls = useMemo(() => {
     if (streamingToolCalls.length === 0) return historicalToolCalls
-    return [...historicalToolCalls, ...streamingToolCalls]
+    if (historicalToolCalls.length === 0) return streamingToolCalls
+    const seen = new Set(historicalToolCalls.map((tc) => tc.id))
+    const unique = streamingToolCalls.filter((tc) => !seen.has(tc.id))
+    return [...historicalToolCalls, ...unique]
   }, [historicalToolCalls, streamingToolCalls])
 
   const toolCallsByMessage = useMemo(() => {


### PR DESCRIPTION
## Problem

Tool calls appeared duplicated in the TaskDetailModal: once at the top of the conversation (grouped in the first Kin message) and again inline at their correct position.

## Root Cause

The 3-second polling fallback (`fetchDetail` every 3s for active tasks) could fetch persisted messages from the DB while SSE streaming was still active. This caused two issues:

1. **Duplicate tool calls**: The same tool call appeared in both `historicalToolCalls` (from persisted messages) and `streamingToolCalls` (from SSE events). The merge was a simple concatenation with no deduplication.
2. **Duplicate message bubble**: The persisted assistant message appeared in `visibleMessages` while the same message was also rendered as the `streamingMessage` bubble.

## Fix

- **`useTaskDetail.ts`**: Deduplicate tool calls by ID when merging historical and streaming lists. Historical entries take precedence (they have the final result data).
- **`TaskDetailModal.tsx`**: Exclude messages from `visibleMessages` when their ID matches the current `streamingMessage`, preventing the same message from rendering twice.

Fixes #233