### PR TITLE
feat: replace message/token compaction thresholds with context usage percentage (#226)

### DIFF
--- a/src/client/components/chat/ChatPanel.tsx
+++ b/src/client/components/chat/ChatPanel.tsx
@@ -59,7 +59,7 @@ interface ChatPanelProps {
   kin: KinInfo
   llmModels: LLMModel[]
   modelUnavailable?: boolean
-  queueState?: { isProcessing: boolean; queueSize: number; contextTokens?: number; contextWindow?: number; contextBreakdown?: { systemPrompt: number; messages: number; tools: number; total: number }; compactingTokens?: number; compactingThreshold?: number; compactingMessages?: number; compactingMessageThreshold?: number }
+  queueState?: { isProcessing: boolean; queueSize: number; contextTokens?: number; contextWindow?: number; contextBreakdown?: { systemPrompt: number; messages: number; tools: number; total: number }; compactingTokens?: number; compactingThreshold?: number; compactingThresholdPercent?: number; compactingMessages?: number }
   onModelChange: (model: string) => void
   onEditKin: () => void
 }
@@ -624,8 +624,8 @@ export function ChatPanel({ kin, llmModels, modelUnavailable = false, queueState
         contextBreakdown={queueState?.contextBreakdown}
         compactingTokens={queueState?.compactingTokens}
         compactingThreshold={queueState?.compactingThreshold}
+        compactingThresholdPercent={queueState?.compactingThresholdPercent}
         compactingMessages={queueState?.compactingMessages}
-        compactingMessageThreshold={queueState?.compactingMessageThreshold}
         toolCallCount={toolCallCount}
         isToolCallsOpen={isToolCallsOpen}
         queueState={queueState}

--- a/src/client/components/chat/ConversationHeader.tsx
+++ b/src/client/components/chat/ConversationHeader.tsx
@@ -64,8 +64,8 @@ interface ConversationHeaderProps {
   contextBreakdown?: { systemPrompt: number; messages: number; tools: number; total: number }
   compactingTokens?: number
   compactingThreshold?: number
+  compactingThresholdPercent?: number
   compactingMessages?: number
-  compactingMessageThreshold?: number
   messages?: ChatMessage[]
   scrollViewportRef?: React.RefObject<HTMLElement | null>
 }
@@ -101,8 +101,8 @@ export const ConversationHeader = memo(function ConversationHeader({
   contextBreakdown,
   compactingTokens,
   compactingThreshold,
+  compactingThresholdPercent,
   compactingMessages,
-  compactingMessageThreshold,
   messages,
   scrollViewportRef,
 }: ConversationHeaderProps) {
@@ -239,7 +239,7 @@ export const ConversationHeader = memo(function ConversationHeader({
                 {t('chat.compactingProximity', {
                   tokens: formatTokenCount(compactingRemaining),
                   messages: compactingMessages ?? 0,
-                  maxMessages: compactingMessageThreshold ?? 0,
+                  thresholdPercent: compactingThresholdPercent ?? 75,
                 })}
               </p>
             )}
@@ -301,7 +301,7 @@ export const ConversationHeader = memo(function ConversationHeader({
                   {t('chat.compactingProximity', {
                     tokens: formatTokenCount(compactingRemaining),
                     messages: compactingMessages ?? 0,
-                    maxMessages: compactingMessageThreshold ?? 0,
+                    thresholdPercent: compactingThresholdPercent ?? 75,
                   })}
                 </p>
               )}
@@ -398,7 +398,7 @@ export const ConversationHeader = memo(function ConversationHeader({
                   <span>{t('chat.compactingProximity', {
                     tokens: formatTokenCount(compactingRemaining),
                     messages: compactingMessages ?? 0,
-                    maxMessages: compactingMessageThreshold ?? 0,
+                    thresholdPercent: compactingThresholdPercent ?? 75,
                   })}</span>
                 </div>
               </div>

--- a/src/client/components/kin/KinFormModal.tsx
+++ b/src/client/components/kin/KinFormModal.tsx
@@ -421,7 +421,7 @@ export function KinFormModal({
     try {
       if (isEdit && onUpdateKin) {
         // Normalize compactingConfig: if both fields are empty, send null to clear the override
-        const effectiveCompactingConfig = (compactingConfig?.messageThreshold != null || compactingConfig?.tokenThreshold != null)
+        const effectiveCompactingConfig = (compactingConfig?.thresholdPercent != null)
           ? compactingConfig
           : null
         await onUpdateKin(kin.id, { name, slug, role, character, expertise, model, providerId, toolConfig, compactingConfig: effectiveCompactingConfig })
@@ -873,38 +873,22 @@ export function KinFormModal({
                               {t('kin.compacting.title')}
                             </Label>
                             <p className="text-xs text-muted-foreground">{t('kin.compacting.overrideHint')}</p>
-                            <div className="grid grid-cols-2 gap-3">
-                              <div className="space-y-1.5">
-                                <Label className="text-xs">{t('kin.compacting.messageThreshold')}</Label>
-                                <Input
-                                  type="number"
-                                  min={1}
-                                  placeholder={t('kin.compacting.messageThresholdPlaceholder', { default: 50 })}
-                                  value={compactingConfig?.messageThreshold ?? ''}
-                                  onChange={(e) => {
-                                    const val = e.target.value ? Number(e.target.value) : null
-                                    setCompactingConfig({ ...compactingConfig, messageThreshold: val, tokenThreshold: compactingConfig?.tokenThreshold ?? null })
-                                    markDirty()
-                                  }}
-                                />
-                                <p className="text-[10px] text-muted-foreground">{t('kin.compacting.messageThresholdHint', { default: 50 })}</p>
-                              </div>
-                              <div className="space-y-1.5">
-                                <Label className="text-xs">{t('kin.compacting.tokenThreshold')}</Label>
-                                <Input
-                                  type="number"
-                                  min={1000}
-                                  step={1000}
-                                  placeholder={t('kin.compacting.tokenThresholdPlaceholder', { default: '30k' })}
-                                  value={compactingConfig?.tokenThreshold ?? ''}
-                                  onChange={(e) => {
-                                    const val = e.target.value ? Number(e.target.value) : null
-                                    setCompactingConfig({ ...compactingConfig, tokenThreshold: val, messageThreshold: compactingConfig?.messageThreshold ?? null })
-                                    markDirty()
-                                  }}
-                                />
-                                <p className="text-[10px] text-muted-foreground">{t('kin.compacting.tokenThresholdHint', { default: '30k' })}</p>
-                              </div>
+                            <div className="space-y-1.5">
+                              <Label className="text-xs">{t('kin.compacting.thresholdPercent')}</Label>
+                              <Input
+                                type="number"
+                                min={50}
+                                max={95}
+                                step={5}
+                                placeholder={t('kin.compacting.thresholdPercentPlaceholder', { default: '75%' })}
+                                value={compactingConfig?.thresholdPercent ?? ''}
+                                onChange={(e) => {
+                                  const val = e.target.value ? Number(e.target.value) : null
+                                  setCompactingConfig({ ...compactingConfig, thresholdPercent: val })
+                                  markDirty()
+                                }}
+                              />
+                              <p className="text-[10px] text-muted-foreground">{t('kin.compacting.thresholdPercentHint', { default: 75 })}</p>
                             </div>
                           </div>
                         </div>

--- a/src/client/hooks/useKins.ts
+++ b/src/client/hooks/useKins.ts
@@ -129,7 +129,7 @@ export function useKins() {
   }, [sseStatus, fetchKins])
 
   // Track which kins are currently processing (queue state from SSE)
-  const [kinQueueState, setKinQueueState] = useState<Map<string, { isProcessing: boolean; queueSize: number; contextTokens?: number; contextWindow?: number; contextBreakdown?: { systemPrompt: number; messages: number; tools: number; total: number }; compactingTokens?: number; compactingThreshold?: number; compactingMessages?: number; compactingMessageThreshold?: number }>>(new Map())
+  const [kinQueueState, setKinQueueState] = useState<Map<string, { isProcessing: boolean; queueSize: number; contextTokens?: number; contextWindow?: number; contextBreakdown?: { systemPrompt: number; messages: number; tools: number; total: number }; compactingTokens?: number; compactingThreshold?: number; compactingThresholdPercent?: number; compactingMessages?: number }>>(new Map())
 
   // Listen for kin lifecycle and queue updates via SSE to keep the list in sync
   useSSE({
@@ -194,8 +194,8 @@ export function useKins() {
           contextBreakdown: (data.contextBreakdown as { systemPrompt: number; messages: number; tools: number; total: number } | undefined) ?? existing?.contextBreakdown,
           compactingTokens: (data.compactingTokens as number | undefined) ?? existing?.compactingTokens,
           compactingThreshold: (data.compactingThreshold as number | undefined) ?? existing?.compactingThreshold,
+          compactingThresholdPercent: (data.compactingThresholdPercent as number | undefined) ?? existing?.compactingThresholdPercent,
           compactingMessages: (data.compactingMessages as number | undefined) ?? existing?.compactingMessages,
-          compactingMessageThreshold: (data.compactingMessageThreshold as number | undefined) ?? existing?.compactingMessageThreshold,
         })
         return next
       })
@@ -232,7 +232,7 @@ export function useKins() {
   // Fetch initial context usage for a kin (so the counter doesn't show "— / —")
   const fetchContextUsage = useCallback(async (kinId: string) => {
     try {
-      const data = await api.get<{ contextTokens: number; contextWindow: number; contextBreakdown?: { systemPrompt: number; messages: number; tools: number; total: number }; compactingTokens?: number; compactingThreshold?: number; compactingMessages?: number; compactingMessageThreshold?: number }>(`/kins/${kinId}/context-usage`)
+      const data = await api.get<{ contextTokens: number; contextWindow: number; contextBreakdown?: { systemPrompt: number; messages: number; tools: number; total: number }; compactingTokens?: number; compactingThreshold?: number; compactingThresholdPercent?: number; compactingMessages?: number }>(`/kins/${kinId}/context-usage`)
       setKinQueueState((prev) => {
         const existing = prev.get(kinId)
         // Don't overwrite if SSE already provided fresh data
@@ -246,8 +246,8 @@ export function useKins() {
           contextBreakdown: data.contextBreakdown,
           compactingTokens: data.compactingTokens,
           compactingThreshold: data.compactingThreshold,
+          compactingThresholdPercent: data.compactingThresholdPercent,
           compactingMessages: data.compactingMessages,
-          compactingMessageThreshold: data.compactingMessageThreshold,
         })
         return next
       })

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -344,7 +344,10 @@
       "messageThresholdPlaceholder": "Default: {{default}}",
       "tokenThresholdPlaceholder": "Default: {{default}}",
       "messageThresholdHint": "Global default: {{default}}",
-      "tokenThresholdHint": "Global default: {{default}}"
+      "tokenThresholdHint": "Global default: {{default}}",
+      "thresholdPercent": "Threshold (%)",
+      "thresholdPercentPlaceholder": "Global default ({{default}})",
+      "thresholdPercentHint": "Compact when context reaches this % of model window. Leave empty for global default ({{default}}%)."
     },
     "avatar": {
       "title": "Choose avatar",
@@ -472,7 +475,7 @@
     "forceCompact": "Force compaction",
     "tooltipContext": "Context window",
     "tooltipCompacting": "Compaction",
-    "compactingProximity": "Compaction in ~{{tokens}} tokens ({{messages}}/{{maxMessages}} msgs)",
+    "compactingProximity": "Compaction at {{thresholdPercent}}% ({{messages}} msgs, ~{{tokens}} tokens remaining)",
     "compactingMarker": "Compaction threshold",
     "moreActions": "More actions",
     "compacting": {
@@ -987,7 +990,11 @@
         "bullet2": "The embedding model makes memories searchable by meaning, so your Kin finds relevant info even if the exact words differ",
         "bullet3": "You don't need expensive models here. Small, fast models handle extraction and embedding just fine",
         "bullet4": "If no extraction model is set, each Kin uses its own chat model for memory extraction"
-      }
+      },
+      "compactingThresholdLabel": "Compaction Threshold",
+      "compactingThresholdDescription": "Compact the conversation when context usage reaches this percentage of the model's context window. Lower values compact more often, higher values use more context before compacting.",
+      "compactingThresholdSaved": "Compaction threshold saved",
+      "compactingThresholdError": "Failed to save compaction threshold"
     },
     "contacts": {
       "title": "Contacts",

--- a/src/client/locales/fr.json
+++ b/src/client/locales/fr.json
@@ -344,7 +344,10 @@
       "messageThresholdPlaceholder": "Défaut : {{default}}",
       "tokenThresholdPlaceholder": "Défaut : {{default}}",
       "messageThresholdHint": "Défaut global : {{default}}",
-      "tokenThresholdHint": "Défaut global : {{default}}"
+      "tokenThresholdHint": "Défaut global : {{default}}",
+      "thresholdPercent": "Seuil (%)",
+      "thresholdPercentPlaceholder": "Defaut global ({{default}})",
+      "thresholdPercentHint": "Compacter quand le contexte atteint ce % de la fenetre du modele. Vide = defaut global ({{default}}%)."
     },
     "avatar": {
       "title": "Choisir l'avatar",
@@ -472,7 +475,7 @@
     "forceCompact": "Forcer la compaction",
     "tooltipContext": "Fenêtre de contexte",
     "tooltipCompacting": "Compaction",
-    "compactingProximity": "Compaction dans ~{{tokens}} tokens ({{messages}}/{{maxMessages}} msgs)",
+    "compactingProximity": "Compaction a {{thresholdPercent}}% ({{messages}} msgs, ~{{tokens}} tokens restants)",
     "compactingMarker": "Seuil de compaction",
     "moreActions": "Plus d'actions",
     "compacting": {
@@ -987,7 +990,11 @@
         "bullet2": "Le modèle d'embedding rend les souvenirs recherchables par le sens, pour retrouver les infos même avec des mots différents",
         "bullet3": "Des modèles petits et rapides suffisent pour l'extraction et l'embedding, pas besoin de modèles coûteux",
         "bullet4": "Si aucun modèle d'extraction n'est défini, chaque Kin utilise son propre modèle de chat"
-      }
+      },
+      "compactingThresholdLabel": "Seuil de compaction",
+      "compactingThresholdDescription": "Compacter la conversation lorsque l'utilisation du contexte atteint ce pourcentage de la fenetre contextuelle du modele. Des valeurs plus basses compactent plus souvent.",
+      "compactingThresholdSaved": "Seuil de compaction sauvegarde",
+      "compactingThresholdError": "Erreur lors de la sauvegarde du seuil"
     },
     "contacts": {
       "title": "Contacts",

--- a/src/client/pages/settings/MemoriesSettings.tsx
+++ b/src/client/pages/settings/MemoriesSettings.tsx
@@ -1,10 +1,45 @@
+import { useState, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
+import { toast } from 'sonner'
 import { MemoryModelConfig } from '@/client/components/common/MemoryModelConfig'
 import { HelpPanel } from '@/client/components/common/HelpPanel'
 import { MemoryList } from '@/client/components/memory/MemoryList'
+import { Label } from '@/client/components/ui/label'
+import { Slider } from '@/client/components/ui/slider'
+import { api } from '@/client/lib/api'
 
 export function MemoriesSettings() {
   const { t } = useTranslation()
+  const [thresholdPercent, setThresholdPercent] = useState(75)
+  const [initialThreshold, setInitialThreshold] = useState(75)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    api.get<{ thresholdPercent: number }>('/settings/compacting-threshold')
+      .then((data) => {
+        setThresholdPercent(data.thresholdPercent)
+        setInitialThreshold(data.thresholdPercent)
+      })
+      .catch(() => { /* use default */ })
+      .finally(() => setLoading(false))
+  }, [])
+
+  const handleThresholdChange = async (value: number[]) => {
+    const newPercent = value[0]!
+    setThresholdPercent(newPercent)
+  }
+
+  const handleThresholdCommit = async (value: number[]) => {
+    const newPercent = value[0]!
+    try {
+      await api.put('/settings/compacting-threshold', { thresholdPercent: newPercent })
+      setInitialThreshold(newPercent)
+      toast.success(t('settings.memories.compactingThresholdSaved'))
+    } catch {
+      setThresholdPercent(initialThreshold)
+      toast.error(t('settings.memories.compactingThresholdError'))
+    }
+  }
 
   return (
     <div className="space-y-4">
@@ -12,6 +47,29 @@ export function MemoriesSettings() {
         <p className="text-sm text-muted-foreground">
           {t('settings.memories.description')}
         </p>
+      </div>
+
+      {/* Compaction threshold */}
+      <div className="space-y-3 rounded-lg border p-4">
+        <div className="flex items-center justify-between">
+          <Label className="text-sm font-medium">
+            {t('settings.memories.compactingThresholdLabel')}
+          </Label>
+          <span className="text-sm font-mono text-muted-foreground">{loading ? '...' : `${thresholdPercent}%`}</span>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {t('settings.memories.compactingThresholdDescription')}
+        </p>
+        {!loading && (
+          <Slider
+            value={[thresholdPercent]}
+            min={50}
+            max={95}
+            step={5}
+            onValueChange={handleThresholdChange}
+            onValueCommit={handleThresholdCommit}
+          />
+        )}
       </div>
 
       <MemoryModelConfig variant="settings" />

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -67,8 +67,12 @@ export const config = {
   },
 
   compacting: {
+    /** @deprecated Use thresholdPercent instead */
     messageThreshold: Number(process.env.COMPACTING_MESSAGE_THRESHOLD ?? 50),
+    /** @deprecated Use thresholdPercent instead */
     tokenThreshold: Number(process.env.COMPACTING_TOKEN_THRESHOLD ?? 30000),
+    /** Trigger compaction when context usage reaches this % of model's context window (default: 75) */
+    thresholdPercent: Number(process.env.COMPACTING_THRESHOLD_PERCENT ?? 75),
     model: process.env.COMPACTING_MODEL ?? undefined,
     maxSnapshotsPerKin: Number(process.env.COMPACTING_MAX_SNAPSHOTS ?? 10),
   },

--- a/src/server/routes/kins.ts
+++ b/src/server/routes/kins.ts
@@ -357,8 +357,8 @@ kinRoutes.get('/:id/context-usage', async (c) => {
       contextBreakdown: cached.breakdown ?? null,
       compactingTokens: compacting.currentTokens,
       compactingThreshold: compacting.tokenThreshold,
+      compactingThresholdPercent: compacting.thresholdPercent,
       compactingMessages: compacting.currentMessages,
-      compactingMessageThreshold: compacting.messageThreshold,
     })
   }
 
@@ -412,8 +412,8 @@ kinRoutes.get('/:id/context-usage', async (c) => {
     contextBreakdown: { systemPrompt: systemPromptTokens, messages: messagesTokens, tools: 0, total: contextTokens },
     compactingTokens: compacting.currentTokens,
     compactingThreshold: compacting.tokenThreshold,
+    compactingThresholdPercent: compacting.thresholdPercent,
     compactingMessages: compacting.currentMessages,
-    compactingMessageThreshold: compacting.messageThreshold,
   })
 })
 

--- a/src/server/routes/settings.ts
+++ b/src/server/routes/settings.ts
@@ -212,4 +212,33 @@ settingsRoutes.put('/hub', async (c) => {
   return c.json({ hubKinId: kinId })
 })
 
+// ─── Compacting Threshold ────────────────────────────────────────────────────
+
+settingsRoutes.get('/compacting-threshold', async (c) => {
+  const { getCompactingThresholdPercent } = await import('@/server/services/app-settings')
+  const { config } = await import('@/server/config')
+  const dbValue = await getCompactingThresholdPercent()
+  return c.json({ thresholdPercent: dbValue ?? config.compacting.thresholdPercent })
+})
+
+settingsRoutes.put('/compacting-threshold', async (c) => {
+  const body = await c.req.json<{ thresholdPercent: number }>()
+  const { thresholdPercent } = body
+
+  if (typeof thresholdPercent !== 'number' || thresholdPercent < 50 || thresholdPercent > 95) {
+    return c.json({ error: { code: 'INVALID_VALUE', message: 'thresholdPercent must be between 50 and 95' } }, 400)
+  }
+
+  const { setCompactingThresholdPercent } = await import('@/server/services/app-settings')
+  await setCompactingThresholdPercent(thresholdPercent)
+
+  sseManager.broadcast({
+    type: 'settings:compacting-threshold-changed',
+    data: { thresholdPercent },
+  })
+
+  log.info({ thresholdPercent }, 'Compacting threshold updated')
+  return c.json({ thresholdPercent })
+})
+
 export { settingsRoutes }

--- a/src/server/services/app-settings.ts
+++ b/src/server/services/app-settings.ts
@@ -88,3 +88,12 @@ export async function setHubKinId(kinId: string | null): Promise<void> {
   if (kinId === null) return deleteSetting('hub_kin_id')
   return setSetting('hub_kin_id', kinId)
 }
+
+export async function getCompactingThresholdPercent(): Promise<number | null> {
+  const v = await getSetting('compacting_threshold_percent')
+  return v ? Number(v) : null
+}
+
+export async function setCompactingThresholdPercent(percent: number): Promise<void> {
+  return setSetting('compacting_threshold_percent', String(Math.max(50, Math.min(95, Math.round(percent)))))
+}

--- a/src/server/services/compacting.ts
+++ b/src/server/services/compacting.ts
@@ -14,6 +14,7 @@ import { config } from '@/server/config'
 import { getExtractionModel } from '@/server/services/app-settings'
 import { createMemory, updateMemory, isDuplicateMemory, pruneStaleMemories } from '@/server/services/memory'
 import { sseManager } from '@/server/sse/index'
+import { getModelContextWindow } from '@/shared/model-context-windows'
 import type { MemoryCategory, KinCompactingConfig } from '@/shared/types'
 
 const log = createLogger('compacting')
@@ -25,8 +26,8 @@ function estimateTokens(text: string): number {
 
 // ─── Per-Kin Threshold Resolution ────────────────────────────────────────────
 
-/** Resolve effective compacting thresholds: per-Kin overrides > global defaults */
-async function getEffectiveThresholds(kinId: string): Promise<{ messageThreshold: number; tokenThreshold: number }> {
+/** Resolve effective compacting threshold percentage: per-Kin override > DB setting > env var default */
+async function getEffectiveThresholdPercent(kinId: string): Promise<number> {
   const kin = await db
     .select({ compactingConfig: kins.compactingConfig })
     .from(kins)
@@ -38,10 +39,23 @@ async function getEffectiveThresholds(kinId: string): Promise<{ messageThreshold
     try { kinConfig = JSON.parse(kin.compactingConfig) as KinCompactingConfig } catch { /* use defaults */ }
   }
 
-  return {
-    messageThreshold: kinConfig?.messageThreshold ?? config.compacting.messageThreshold,
-    tokenThreshold: kinConfig?.tokenThreshold ?? config.compacting.tokenThreshold,
-  }
+  if (kinConfig?.thresholdPercent != null) return kinConfig.thresholdPercent
+
+  // Check DB-stored global setting
+  const { getCompactingThresholdPercent } = await import('@/server/services/app-settings')
+  const dbPercent = await getCompactingThresholdPercent()
+  return dbPercent ?? config.compacting.thresholdPercent
+}
+
+/** Get the model context window for a Kin */
+async function getKinContextWindow(kinId: string): Promise<number> {
+  const kin = await db
+    .select({ model: kins.model })
+    .from(kins)
+    .where(eq(kins.id, kinId))
+    .get()
+
+  return getModelContextWindow(kin?.model ?? 'unknown')
 }
 
 /** Get non-compacted message stats for a Kin (shared by shouldCompact + getCompactingProximity) */
@@ -83,18 +97,18 @@ async function getNonCompactedStats(kinId: string): Promise<{ currentTokens: num
 
 /**
  * Evaluate whether compacting should trigger for a Kin.
- * Returns true if message count or token count exceeds thresholds.
+ * Returns true if token count exceeds the configured percentage of model context window.
  */
 async function shouldCompact(kinId: string): Promise<boolean> {
-  const [stats, thresholds] = await Promise.all([
+  const [stats, thresholdPercent, contextWindow] = await Promise.all([
     getNonCompactedStats(kinId),
-    getEffectiveThresholds(kinId),
+    getEffectiveThresholdPercent(kinId),
+    getKinContextWindow(kinId),
   ])
 
   if (stats.currentMessages === 0) return false
-  if (stats.currentMessages > thresholds.messageThreshold) return true
-  if (stats.currentTokens > thresholds.tokenThreshold) return true
-  return false
+  const tokenThreshold = Math.floor((contextWindow * thresholdPercent) / 100)
+  return stats.currentTokens > tokenThreshold
 }
 
 // ─── Public: compacting proximity for UI ─────────────────────────────────────
@@ -102,22 +116,27 @@ async function shouldCompact(kinId: string): Promise<boolean> {
 export interface CompactingProximity {
   currentTokens: number
   tokenThreshold: number
+  thresholdPercent: number
+  contextWindow: number
   currentMessages: number
-  messageThreshold: number
 }
 
 /** Get compacting proximity data for display in the chat UI */
 export async function getCompactingProximity(kinId: string): Promise<CompactingProximity> {
-  const [stats, thresholds] = await Promise.all([
+  const [stats, thresholdPercent, contextWindow] = await Promise.all([
     getNonCompactedStats(kinId),
-    getEffectiveThresholds(kinId),
+    getEffectiveThresholdPercent(kinId),
+    getKinContextWindow(kinId),
   ])
+
+  const tokenThreshold = Math.floor((contextWindow * thresholdPercent) / 100)
 
   return {
     currentTokens: stats.currentTokens,
-    tokenThreshold: thresholds.tokenThreshold,
+    tokenThreshold,
+    thresholdPercent,
+    contextWindow,
     currentMessages: stats.currentMessages,
-    messageThreshold: thresholds.messageThreshold,
   }
 }
 

--- a/src/server/services/kin-engine.ts
+++ b/src/server/services/kin-engine.ts
@@ -80,7 +80,7 @@ export function getLastContextUsage(kinId: string) {
 }
 
 // Cache of last computed compacting proximity per Kin
-const lastCompactingProximity = new Map<string, { compactingTokens: number; compactingThreshold: number; compactingMessages: number; compactingMessageThreshold: number }>()
+const lastCompactingProximity = new Map<string, { compactingTokens: number; compactingThreshold: number; compactingThresholdPercent: number; compactingMessages: number }>()
 
 /**
  * Extract a human-readable message from a raw API error object.
@@ -495,8 +495,8 @@ export async function processNextMessage(kinId: string): Promise<boolean> {
     lastCompactingProximity.set(kinId, {
       compactingTokens: compactingData.currentTokens,
       compactingThreshold: compactingData.tokenThreshold,
+      compactingThresholdPercent: compactingData.thresholdPercent,
       compactingMessages: compactingData.currentMessages,
-      compactingMessageThreshold: compactingData.messageThreshold,
     })
 
     // Update the queue event with real context usage (the initial queue:update

--- a/src/server/sse/types.ts
+++ b/src/server/sse/types.ts
@@ -67,6 +67,7 @@ export type SSEEventType =
   | 'plugin:configUpdated'
   | 'plugin:autoDisabled'
   | 'settings:hub-changed'
+| 'settings:compacting-threshold-changed'
   | 'version:update-available'
   | 'log:entry'
   | 'connected'

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -131,10 +131,12 @@ export interface KinToolConfig {
 
 /** Per-Kin compacting configuration (stored as JSON in kins.compacting_config) */
 export interface KinCompactingConfig {
-  /** Message count threshold before compacting triggers (null = use global default) */
+  /** @deprecated Use thresholdPercent instead */
   messageThreshold?: number | null
-  /** Token count threshold before compacting triggers (null = use global default) */
+  /** @deprecated Use thresholdPercent instead */
   tokenThreshold?: number | null
+  /** Trigger compaction at this % of model's context window (null = use global default) */
+  thresholdPercent?: number | null
 }
 
 /** Task summary as returned by GET /api/tasks */


### PR DESCRIPTION
Replaces the dual COMPACTING_MESSAGE_THRESHOLD / COMPACTING_TOKEN_THRESHOLD system with a single context usage percentage that adapts to any model's context window.

Closes #226

### Backend
- compacting.ts: shouldCompact() now uses (contextWindow * thresholdPercent) / 100
- getEffectiveThresholdPercent(): per-kin > DB setting > env var (default: 75%)
- New GET/PUT /api/settings/compacting-threshold endpoints

### Frontend
- Settings > Memory: slider (50-95%) for global compaction threshold
- Kin form modal: per-kin override with single thresholdPercent field
- ConversationHeader: simplified proximity tooltip showing percentage
- Updated en/fr i18n keys

Old env vars deprecated but kept for backward compat.