### PR TITLE
fix: pass cron name as task title in spawnTask() calls

### DIFF
--- a/src/server/services/crons.ts
+++ b/src/server/services/crons.ts
@@ -279,6 +279,7 @@ export async function triggerCronManually(cronId: string): Promise<{ taskId: str
 
   const { taskId } = await spawnTask({
     parentKinId: cron.kinId,
+    title: cron.name,
     description: cron.taskDescription,
     mode: 'async',
     spawnType: cron.targetKinId ? 'other' : 'self',
@@ -327,6 +328,7 @@ async function triggerCron(cronId: string) {
   // Spawn sub-Kin task — async mode (result is informational, no LLM turn)
   const { taskId } = await spawnTask({
     parentKinId: cron.kinId,
+    title: cron.name,
     description: cron.taskDescription,
     mode: 'async',
     spawnType: cron.targetKinId ? 'other' : 'self',


### PR DESCRIPTION
## Summary

Cron-spawned tasks were missing a `title`, causing the UI to fall back to displaying the full `task_description` as the task label (since the formatting uses `task.title ?? task.description`).

## Changes

Added `title: cron.name` to both `spawnTask()` calls in `src/server/services/crons.ts`:

1. **`triggerCronManually()`** — called when a user manually triggers a cron
2. **`triggerCron()`** — called by the scheduler on cron schedule

This ensures cron-spawned tasks get a clean, short display name matching the cron's name, consistent with how `spawn_self`/`spawn_kin` tools already pass a title.

Closes #271