### PR TITLE
feat: add dedicated prompt viewer modal in TaskDetailModal

### DIFF
--- a/src/client/components/sidebar/TaskDetailModal.tsx
+++ b/src/client/components/sidebar/TaskDetailModal.tsx
@@ -9,6 +9,7 @@ import {
   DialogFooter,
   DialogClose,
 } from '@/client/components/ui/dialog'
+import { Tooltip, TooltipTrigger, TooltipContent } from '@/client/components/ui/tooltip'
 import { Button } from '@/client/components/ui/button'
 import { Badge } from '@/client/components/ui/badge'
 import { Avatar, AvatarFallback, AvatarImage } from '@/client/components/ui/avatar'
@@ -33,6 +34,7 @@ import {
   Layers,
   Wrench,
   Cpu,
+  FileText,
 } from 'lucide-react'
 import type { TaskStatus } from '@/shared/types'
 
@@ -96,6 +98,7 @@ export function TaskDetailModal({
   )
   const bottomRef = useRef<HTMLDivElement>(null)
   const [isToolCallsOpen, setIsToolCallsOpen] = useState(false)
+  const [isPromptOpen, setIsPromptOpen] = useState(false)
   const toggleToolCalls = useCallback(() => setIsToolCallsOpen((prev) => !prev), [])
 
   // Filter out messages already represented elsewhere in the modal:
@@ -119,9 +122,12 @@ export function TaskDetailModal({
     bottomRef.current?.scrollIntoView({ block: 'end', behavior: 'smooth' })
   }, [visibleMessages, streamingMessage, isStreaming, pendingPrompts])
 
-  // Reset tool calls panel when modal closes
+  // Reset panels when modal closes
   useEffect(() => {
-    if (!open) setIsToolCallsOpen(false)
+    if (!open) {
+      setIsToolCallsOpen(false)
+      setIsPromptOpen(false)
+    }
   }, [open])
 
   const statusConfig = task ? STATUS_CONFIG[task.status] : null
@@ -160,6 +166,9 @@ export function TaskDetailModal({
                       : task?.description) ??
                     t('common.loading')}
                 </DialogTitle>
+                <DialogDescription className="sr-only">
+                  {task?.description ?? t('taskDetail.promptDescription')}
+                </DialogDescription>
                 {statusConfig && StatusIcon && (
                   <Badge variant={statusConfig.badgeVariant} className="shrink-0 gap-1">
                     <StatusIcon className={cn('size-3', statusConfig.iconClass)} />
@@ -167,12 +176,6 @@ export function TaskDetailModal({
                   </Badge>
                 )}
               </div>
-
-              {task?.title && task.description && (
-                <DialogDescription className="mt-1 line-clamp-2">
-                  {task.description}
-                </DialogDescription>
-              )}
 
               {task && (
                 <div className="flex items-center gap-3 mt-2 text-[11px] text-muted-foreground">
@@ -211,6 +214,22 @@ export function TaskDetailModal({
                       <Wrench className="size-3" />
                       {toolCallCount}
                     </Button>
+                  )}
+                  {task.description && (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="h-5 gap-1 px-1.5 text-[10px]"
+                          onClick={() => setIsPromptOpen(true)}
+                        >
+                          <FileText className="size-3" />
+                          {t('taskDetail.viewPrompt')}
+                        </Button>
+                      </TooltipTrigger>
+                      <TooltipContent>{t('taskDetail.viewPromptTooltip')}</TooltipContent>
+                    </Tooltip>
                   )}
                 </div>
               )}
@@ -319,6 +338,34 @@ export function TaskDetailModal({
             />
           </div>
         </div>
+
+        {/* Prompt viewer dialog */}
+        {task?.description && (
+          <Dialog open={isPromptOpen} onOpenChange={setIsPromptOpen}>
+            <DialogContent className="sm:max-w-2xl max-h-[80vh] flex flex-col gap-0">
+              <DialogHeader className="pb-3 border-b border-border">
+                <DialogTitle className="text-base">
+                  {task.title ?? t('taskDetail.prompt')}
+                </DialogTitle>
+                <DialogDescription className="sr-only">
+                  {t('taskDetail.promptDescription')}
+                </DialogDescription>
+              </DialogHeader>
+              <div className="overflow-y-auto max-h-[60vh] py-4 px-1">
+                <div className="text-sm text-foreground">
+                  <MarkdownContent content={task.description} isUser={false} />
+                </div>
+              </div>
+              <DialogFooter className="pt-3 border-t border-border">
+                <DialogClose asChild>
+                  <Button variant="outline" size="sm">
+                    {t('taskDetail.close')}
+                  </Button>
+                </DialogClose>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
+        )}
 
         {/* Footer */}
         <DialogFooter className="pt-3 border-t border-border">

--- a/src/client/locales/de.json
+++ b/src/client/locales/de.json
@@ -692,7 +692,11 @@
     "result": "Ergebnis",
     "error": "Fehler",
     "cancel": "Aufgabe abbrechen",
-    "close": "Schließen"
+    "close": "Schließen",
+    "viewPrompt": "Prompt",
+    "viewPromptTooltip": "Vollständigen Aufgaben-Prompt anzeigen",
+    "prompt": "Aufgaben-Prompt",
+    "promptDescription": "Vollständiger Inhalt des Aufgaben-Prompts"
   },
   "settings": {
     "title": "Einstellungen",

--- a/src/client/locales/en.json
+++ b/src/client/locales/en.json
@@ -699,7 +699,11 @@
     "result": "Result",
     "error": "Error",
     "cancel": "Cancel task",
-    "close": "Close"
+    "close": "Close",
+    "viewPrompt": "Prompt",
+    "viewPromptTooltip": "View full task prompt",
+    "prompt": "Task prompt",
+    "promptDescription": "Full task prompt content"
   },
   "settings": {
     "title": "Settings",

--- a/src/client/locales/es.json
+++ b/src/client/locales/es.json
@@ -692,7 +692,11 @@
     "result": "Resultado",
     "error": "Error",
     "cancel": "Cancelar tarea",
-    "close": "Cerrar"
+    "close": "Cerrar",
+    "viewPrompt": "Prompt",
+    "viewPromptTooltip": "Ver el prompt completo de la tarea",
+    "prompt": "Prompt de la tarea",
+    "promptDescription": "Contenido completo del prompt de la tarea"
   },
   "settings": {
     "title": "Ajustes",

--- a/src/client/locales/fr.json
+++ b/src/client/locales/fr.json
@@ -699,7 +699,11 @@
     "result": "Résultat",
     "error": "Erreur",
     "cancel": "Annuler la tâche",
-    "close": "Fermer"
+    "close": "Fermer",
+    "viewPrompt": "Prompt",
+    "viewPromptTooltip": "Voir le prompt complet de la tâche",
+    "prompt": "Prompt de la tâche",
+    "promptDescription": "Contenu complet du prompt de la tâche"
   },
   "settings": {
     "title": "Paramètres",


### PR DESCRIPTION
## Summary

Closes #272

When a task has both a `title` and a long `description` (task prompt), the description was previously shown as a `DialogDescription` with `line-clamp-2` — truncated to 2 lines, no Markdown rendering, and no way to see the full prompt.

## Changes

### TaskDetailModal.tsx
- **Removed** the `DialogDescription` that showed the truncated prompt text in the header
- **Added** a screen-reader-only `DialogDescription` for accessibility (avoids Radix UI console warning)
- **Added** a "Prompt" button with `FileText` icon in the metadata row (next to depth, mode, model, tool calls) with tooltip
- **Added** a nested `Dialog` that opens on click, showing:
  - Full prompt rendered with the existing `MarkdownContent` component
  - Properly scrollable container (`overflow-y-auto` with `max-h-[60vh]`)
  - Clean header with task title
  - Close button
- **Added** `isPromptOpen` state, reset when modal closes
- **Added** imports for `Tooltip`, `TooltipTrigger`, `TooltipContent`, `FileText`

### i18n (en, fr, de, es)
Added 4 new keys to `taskDetail` namespace:
- `viewPrompt` — button label
- `viewPromptTooltip` — tooltip text
- `prompt` — fallback dialog title when task has no title
- `promptDescription` — screen-reader dialog description

## Design decisions
- Uses existing shadcn/ui `Dialog`, `Button`, `Tooltip`, and `MarkdownContent` components
- Uses design tokens only (no hardcoded colors) — works across all 8 palettes in light/dark mode
- All text uses `useTranslation()` — no hardcoded strings
- The prompt button only appears when `task.description` is truthy
- Nested dialog pattern is consistent with how tool calls viewer works in the same component