### PR TITLE
fix: prevent cron detail modal content overflow hiding action buttons

### DIFF
--- a/src/client/components/sidebar/CronDetailModal.tsx
+++ b/src/client/components/sidebar/CronDetailModal.tsx
@@ -176,9 +176,9 @@ export function CronDetailModal({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-h-[80vh] flex flex-col gap-0 sm:max-w-2xl">
+        <DialogContent className="max-h-[85vh] overflow-hidden flex flex-col gap-0 !p-0 sm:max-w-2xl">
           {/* Header */}
-          <DialogHeader className="pb-3 border-b border-border">
+          <DialogHeader className="shrink-0 px-6 pt-6 pb-3 border-b border-border">
             <div className="flex items-center gap-3">
               <Avatar className="size-9 shrink-0">
                 {cron.kinAvatarUrl && <AvatarImage src={cron.kinAvatarUrl} alt={kinName} />}
@@ -213,7 +213,7 @@ export function CronDetailModal({
           </DialogHeader>
 
           {/* Content */}
-          <div className="py-4">
+          <div className="flex-1 overflow-y-auto min-h-0 px-6 py-4">
             <div className="space-y-4">
               {/* Schedule */}
               <div className="space-y-1">
@@ -377,7 +377,7 @@ export function CronDetailModal({
           </div>
 
           {/* Footer */}
-          <DialogFooter className="flex-row items-center gap-2 pt-3 border-t border-border">
+          <DialogFooter className="shrink-0 flex-row items-center gap-2 px-6 pb-6 pt-3 border-t border-border">
             {cron.requiresApproval && (
               <Button
                 size="sm"


### PR DESCRIPTION
## Problem

Closes #273

When a cron job has long instruction text in the `CronDetailModal`, the content overflows the modal body, pushing the footer action buttons (Modifier/Dupliquer/Exécuter/Fermer) off-screen and making them unclickable.

## Solution

Applied proper flex layout to the modal so the body scrolls while header and footer stay fixed:

| Element | Change |
|---|---|
| `DialogContent` | `max-h-[85vh]` (was `80vh`), added `overflow-hidden` and `!p-0` (padding moved to sections) |
| `DialogHeader` | Added `shrink-0 px-6 pt-6` — never shrinks, never scrolls |
| Body `div` | Added `flex-1 overflow-y-auto min-h-0 px-6 py-4` — scrollable content area |
| `DialogFooter` | Added `shrink-0 px-6 pb-6` — always visible at bottom |

## What changed

- Only `CronDetailModal.tsx` — 4 className adjustments
- No functional changes, only layout/scroll behavior
- Uses existing Tailwind classes only