### PR TITLE
fix: webhook filter tester — truncated payload, false positive, textarea overflow (closes #284)

### DIFF
--- a/src/client/components/webhook/WebhookFormDialog.tsx
+++ b/src/client/components/webhook/WebhookFormDialog.tsx
@@ -147,7 +147,14 @@ export function WebhookFormDialog({
       setSuggestedFields(data.fields)
       setLastPayload(data.lastPayload)
       if (data.lastPayload && !testPayload) {
-        setTestPayload(data.lastPayload)
+        // Pretty-print JSON for readability and to prevent horizontal overflow
+        let formatted = data.lastPayload
+        try {
+          formatted = JSON.stringify(JSON.parse(data.lastPayload), null, 2)
+        } catch {
+          // Not valid JSON — use as-is
+        }
+        setTestPayload(formatted)
       }
     } catch {
       // Ignore — suggestions are optional
@@ -564,7 +571,7 @@ export function WebhookFormDialog({
 
                 {/* Test zone */}
                 {filterMode && (
-                  <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-3">
+                  <div className="space-y-3 rounded-lg border border-border bg-muted/30 p-3 overflow-hidden">
                     <Label className="inline-flex items-center gap-1.5 text-sm font-medium">
                       <FlaskConical className="size-4" />
                       {t('settings.webhooks.filterTest')}
@@ -576,8 +583,9 @@ export function WebhookFormDialog({
                         setTestResult(null)
                       }}
                       placeholder={t('settings.webhooks.filterTestPayloadPlaceholder')}
-                      rows={4}
-                      className="font-mono text-xs"
+                      rows={6}
+                      className="font-mono text-xs resize-y [overflow-wrap:break-word] [word-break:break-all]"
+                      style={{ maxWidth: '100%' }}
                     />
                     <div className="flex items-center gap-3">
                       <Button

--- a/src/server/services/webhooks.ts
+++ b/src/server/services/webhooks.ts
@@ -217,7 +217,7 @@ export function evaluateFilter(config: FilterConfig, payload: string): FilterRes
     try {
       parsed = JSON.parse(payload)
     } catch {
-      return { passed: true, error: 'non-json' }
+      return { passed: false, error: 'non-json' }
     }
 
     const raw = extractByPath(parsed, config.filterField)
@@ -227,7 +227,7 @@ export function evaluateFilter(config: FilterConfig, payload: string): FilterRes
     try {
       allowedValues = config.filterAllowedValues ? JSON.parse(config.filterAllowedValues) : []
     } catch {
-      return { passed: true, error: 'invalid-allowed-values' }
+      return { passed: false, error: 'invalid-allowed-values' }
     }
 
     if (allowedValues.length === 0) {
@@ -328,7 +328,7 @@ export async function getFilteredCounts(webhookIds: string[]): Promise<Record<st
 
 // ─── Trigger ────────────────────────────────────────────────────────────────
 
-const MAX_LOG_PAYLOAD_BYTES = 10_240 // 10 KB
+const MAX_LOG_PAYLOAD_BYTES = 524_288 // 512 KB
 
 export async function triggerWebhook(webhookId: string, payload: string, sourceIp?: string) {
   const webhook = await db.select().from(webhooks).where(eq(webhooks.id, webhookId)).get()


### PR DESCRIPTION
# Fix: Webhook Filter Tester — 3 Bugs

Closes #284

## Bug 1: Last payload truncated (invalid JSON)

**Root cause:** `MAX_LOG_PAYLOAD_BYTES` in `src/server/services/webhooks.ts` was set to `10_240` (10 KB). Webhook payloads were truncated mid-string when stored in `webhook_logs`, producing invalid JSON that was then served to the filter tester UI.

**Fix:** Increased `MAX_LOG_PAYLOAD_BYTES` to `524_288` (512 KB). The DB column is already `text()` with no limit, so this was purely a service-level constraint. 512 KB is generous for webhook payloads while still preventing unbounded storage.

## Bug 2: Filter shows "PASS" on invalid JSON (false positive)

**Root cause:** In `evaluateFilter()` (simple mode), when `JSON.parse()` fails, the function returned `{ passed: true, error: 'non-json' }`. This caused the UI to show both ✅ "PASS" and ❌ "Parse error" simultaneously — contradictory.

**Fix:** Changed to `{ passed: false, error: 'non-json' }`. If the payload can't be parsed as JSON, the simple filter (which relies on JSON field extraction) cannot match, so the payload should be dropped. Same fix applied to `invalid-allowed-values` error case.

## Bug 3: Textarea overflows modal horizontally

**Root cause:** The test payload textarea had no word-wrapping constraints. Long single-line JSON (common in webhook payloads) expanded the textarea beyond the modal boundary.

**Fix:**
- Added `overflow-wrap: break-word` and `word-break: break-all` on the textarea to force text wrapping
- Added `overflow-hidden` on the test zone container to prevent any overflow
- Added `resize-y` to allow only vertical resizing
- **Auto-format JSON with pretty-print** (`JSON.stringify(JSON.parse(...), null, 2)`) when auto-populating from last payload — this is the most impactful fix as it makes the payload readable and naturally wraps at reasonable widths
- Increased default rows from 4 to 6 for better readability of formatted JSON

## Files changed

- `src/server/services/webhooks.ts` — Bug 1 (payload limit) + Bug 2 (filter logic)
- `src/client/components/webhook/WebhookFormDialog.tsx` — Bug 3 (textarea overflow + JSON pretty-print)