### PR TITLE
fix: auto-trust private/LAN IPs for Better Auth origin validation (#312)

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,10 @@ services:
       - KINBOT_DATA_DIR=/app/data
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
       - LOG_LEVEL=${LOG_LEVEL:-info}
-      # Uncomment to set the public-facing URL (needed for webhooks, invitations)
+      # Public-facing URL (needed for webhooks, invitations, and external access).
+      # If accessing KinBot from another device on your LAN (e.g. http://192.168.1.5:3000),
+      # set this to the URL you use in the browser. Private/LAN IPs are auto-trusted
+      # for auth, but PUBLIC_URL is still needed for correct links in webhooks/invitations.
       # - PUBLIC_URL=https://kinbot.example.com
     healthcheck:
       test: ["CMD", "bun", "-e", "fetch('http://localhost:3000/api/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"]

--- a/src/server/auth/index.ts
+++ b/src/server/auth/index.ts
@@ -5,6 +5,65 @@ import { db } from '@/server/db/index'
 import * as schema from '@/server/db/schema'
 import { config } from '@/server/config'
 
+/**
+ * Check whether a hostname is a private/loopback address.
+ * Covers RFC 1918 (10.x, 172.16-31.x, 192.168.x), loopback (127.x, ::1),
+ * link-local (169.254.x, fe80::), and localhost aliases.
+ */
+function isPrivateHost(hostname: string): boolean {
+  if (hostname === 'localhost' || hostname === '::1') return true
+  // IPv6 bracket notation (e.g. [::1])
+  const h = hostname.startsWith('[') ? hostname.slice(1, -1) : hostname
+  if (h === '::1' || h.startsWith('fe80:') || h.startsWith('fd')) return true
+  // IPv4 private ranges
+  const parts = h.split('.').map(Number)
+  if (parts.length !== 4 || parts.some(isNaN)) return false
+  const [a, b] = parts
+  if (a === 127) return true                    // 127.0.0.0/8
+  if (a === 10) return true                     // 10.0.0.0/8
+  if (a === 172 && b >= 16 && b <= 31) return true // 172.16.0.0/12
+  if (a === 192 && b === 168) return true       // 192.168.0.0/16
+  if (a === 169 && b === 254) return true       // 169.254.0.0/16 (link-local)
+  return false
+}
+
+/** Static list of always-trusted origins (publicUrl + dev servers). */
+const STATIC_TRUSTED_ORIGINS = [
+  config.publicUrl,
+  'http://localhost:5173', 'http://localhost:5174', 'http://localhost:3000',
+  'http://127.0.0.1:5173', 'http://127.0.0.1:5174', 'http://127.0.0.1:3000',
+]
+
+/**
+ * Build the trustedOrigins config for Better Auth.
+ *
+ * When TRUSTED_ORIGINS is explicitly set, use that list verbatim.
+ * Otherwise, use a dynamic function that auto-trusts any origin from
+ * a private/loopback IP — essential for Docker and LAN access where
+ * users access KinBot via their NAS/server IP (e.g. http://192.168.1.5:3000).
+ */
+function buildTrustedOrigins(): string[] | ((request: Request) => Promise<string[]>) {
+  if (process.env.TRUSTED_ORIGINS) {
+    return process.env.TRUSTED_ORIGINS.split(',')
+  }
+
+  return async (request: Request) => {
+    const origins = [...STATIC_TRUSTED_ORIGINS]
+    const origin = request.headers.get('origin')
+    if (origin) {
+      try {
+        const url = new URL(origin)
+        if (isPrivateHost(url.hostname)) {
+          origins.push(origin)
+        }
+      } catch {
+        // Invalid origin URL — ignore
+      }
+    }
+    return origins
+  }
+}
+
 export const auth = betterAuth({
   baseURL: process.env.BETTER_AUTH_BASE_URL ?? config.publicUrl,
   secret: process.env.BETTER_AUTH_SECRET ?? config.encryptionKey,
@@ -33,13 +92,7 @@ export const auth = betterAuth({
       maxAge: 5 * 60, // 5 minutes
     },
   },
-  trustedOrigins: process.env.TRUSTED_ORIGINS
-    ? process.env.TRUSTED_ORIGINS.split(',')
-    : [
-        config.publicUrl,
-        'http://localhost:5173', 'http://localhost:5174', 'http://localhost:3000',
-        'http://127.0.0.1:5173', 'http://127.0.0.1:5174', 'http://127.0.0.1:3000',
-      ],
+  trustedOrigins: buildTrustedOrigins(),
 })
 
 export type Session = typeof auth.$Infer.Session


### PR DESCRIPTION
## Description

Fixes the "Invalid origin" error that prevents login when accessing KinBot from a LAN IP address (e.g. `http://192.168.178.43:3000`), which is a common scenario for Docker users on NAS devices and home servers.

### Root cause

Better Auth validates the `Origin` header of incoming requests against a configured `trustedOrigins` list. Previously, this list only included:
- `config.publicUrl` (defaults to `http://localhost:3333`)
- Hardcoded `localhost` / `127.0.0.1` entries on ports 5173, 5174, 3000

When a user accesses KinBot via their NAS/server's LAN IP (e.g. `http://192.168.178.43:3000`), the origin doesn't match any trusted origin, causing `ERROR [Better Auth]: Invalid origin: http://192.168.178.43:3000`.

### Fix

When `TRUSTED_ORIGINS` is not explicitly set, we now use a **dynamic function** (supported by Better Auth) that:
1. Always trusts the static origins (`publicUrl` + dev servers)
2. **Auto-trusts any origin from a private/loopback IP** — covers RFC 1918 ranges (`10.x.x.x`, `172.16-31.x.x`, `192.168.x.x`), loopback (`127.x.x.x`, `::1`), link-local (`169.254.x.x`, `fe80::`, `fd..`), and `localhost`

This is safe because KinBot is a self-hosted tool and private network origins should always be trusted. Users who set `TRUSTED_ORIGINS` explicitly still get the exact list they configured (no behavior change).

### Changes

- **`src/server/auth/index.ts`**: Added `isPrivateHost()` helper and `buildTrustedOrigins()` function that dynamically trusts private IPs
- **`docker/docker-compose.yml`**: Improved comments about `PUBLIC_URL` to clarify that LAN IPs are auto-trusted for auth

Closes #312

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / cleanup
- [ ] Documentation
- [ ] CI / Build
- [ ] Tests
- [ ] Breaking change

## How to Test

1. Run KinBot in Docker without setting `PUBLIC_URL` or `TRUSTED_ORIGINS`
2. Access KinBot from another device on the LAN via the host's IP (e.g. `http://192.168.x.x:3000`)
3. Login should work without "Invalid origin" errors

- [x] Manual testing
- [ ] Unit tests
- [ ] E2E tests

## Checklist

- [x] I've read the Contributing Guide
- [x] I've tested this locally
- [x] New code follows existing patterns and conventions
- [x] No hardcoded colors
- [x] Shared types in src/shared/types.ts