### PR TITLE
feat(plugins): add teamspeak plugin (chat + TTS bridge to ts-bot)

### DIFF
--- a/plugins/teamspeak/README.md
+++ b/plugins/teamspeak/README.md
@@ -1,0 +1,127 @@
+# KinBot Plugin: TeamSpeak
+
+Bridges KinBot to a TeamSpeak server via the local **ts-bot** WebSocket API.
+
+It contributes:
+
+- **A `teamspeak` channel adapter** that ingests TeamSpeak chat messages (and,
+  when wake-word transcription is enabled in ts-bot, voice transcriptions) and
+  routes outgoing replies to **chat + TTS** following these rules:
+  - Private message → chat only (no TTS).
+  - Public channel → TTS only. **ts-bot already echoes the spoken text to the
+    channel chat automatically** (so muted users can read it), so the plugin
+    does NOT send a duplicate chat copy on this path.
+  - Reply longer than `ttsMaxChars` → full text sent explicitly to chat +
+    short TTS notice ("J'ai répondu en chat..."); ts-bot will additionally
+    echo that short notice to chat.
+  - When `enableTtsOnPublic = false`, public replies fall back to chat only.
+- **Tools** (auto-namespaced as `plugin_teamspeak_*` by KinBot):
+  - `get_status` — list channels & clients, show the bot's current location.
+  - `speak` — force TTS playback in the bot's current channel.
+  - `send_chat` — send a chat message to the channel or a private user.
+  - `move_channel` — move the bot to another channel.
+  - `stop_speaking` — interrupt ongoing TTS.
+
+## Requirements
+
+- KinBot **≥ 0.39.0** (uses `IncomingMessage.metadata` for structured channel context).
+- A running **ts-bot** instance with its WebSocket exposed locally (default
+  `ws://127.0.0.1:8080/ws`, no auth — it is meant for localhost only).
+
+## Installation
+
+The plugin lives at `plugins/teamspeak/` inside the KinBot repo. Restart
+KinBot or click **Reload Plugins** in the UI to pick it up.
+
+## Configuration
+
+Open **Settings → Plugins → TeamSpeak**:
+
+| Field | Default | Notes |
+|---|---|---|
+| `wsUrl` | `ws://127.0.0.1:8080/ws` | URL of the ts-bot WebSocket. |
+| `defaultVoice` | _(empty)_ | TTS voice id (e.g. `ff_siwis`). Empty = ts-bot server default. |
+| `ttsMaxChars` | `300` | Replies longer than this are spoken as a short notice; the full text still goes to chat. `0` disables the soft limit. |
+| `enableTtsOnPublic` | `true` | Toggle TTS in public channels. Chat copy is always sent regardless. |
+| `ttsTooLongNotice` | `J'ai répondu en chat, c'était trop long pour le vocal.` | Sentence spoken when the reply is too long. |
+| `reconnectMaxBackoffMs` | `30000` | Upper bound for exponential reconnect backoff. |
+
+## Usage
+
+1. Make sure ts-bot is running and reachable.
+2. In KinBot, create a channel with platform `teamspeak`. Any non-empty value
+   for `wsUrl` in the per-channel config will override the plugin-level
+   `wsUrl`; otherwise the plugin default applies.
+3. Send a chat message in the TS channel where the bot lives — the assigned
+   Kin will receive it as an incoming message with full structured context
+   (modality, presence, channel, sender) in the `<channel-context>` block.
+
+## Channel context exposed to the LLM
+
+Each incoming message carries a `metadata` object that KinBot serializes into
+the `<channel-context>` prompt block:
+
+```jsonc
+{
+  "modality": "text" | "voice",
+  "chatType": "public_channel" | "private",
+  "channel": { "id": 5, "name": "Gaming" } | null,
+  "sender":  { "uid": "<base64>", "name": "Alice", "session_id": 3 },
+  "present": [{ "id": 7, "name": "Bob" }, ...] | null,
+  "bot":     { "channel_id": 5, "channel_name": "Gaming" }
+}
+```
+
+Voice messages additionally include `transcription = { confidence, language, duration_ms }`.
+
+## Known limitations / POC scope
+
+- **No automatic contact creation.** When the plugin sees a new sender it just
+  logs `new sender detected: <uid>` (the plugin runtime does not yet have
+  access to the per-Kin contact tools). Integration with `find_contact_by_identifier`
+  is planned for v2.
+- **Wake-word / mention filtering is delegated to the LLM.** The plugin
+  forwards every chat message it receives. ts-bot's wake-word system handles
+  the voice side; chat filtering will be refined later.
+- **No native message IDs.** TeamSpeak chat has no per-message identifier, so
+  the plugin synthesizes UUIDs for `platformMessageId`.
+- The `sender_uid` from ts-bot arrives as a byte array (not a base64 string
+  as the doc once claimed). The plugin's `normalizeUid` helper accepts both
+  shapes and emits a stable base64 identifier.
+- The `welcome` event is emitted with `nickname` (not `bot_nickname`); the
+  client accepts either for forward compatibility.
+- For `send_message` with `target = "private"`, ts-bot expects `recipient` as
+  a **string** (e.g. `"11033"`). The plugin already serializes accordingly.
+- The bot's `wsUrl` is unauthenticated and meant for localhost only. Don't
+  expose it to the public network.
+- **No KinBot `ws:*` permission scheme.** KinBot only enforces `http:<host>`
+  in plugin manifests today, so this plugin only declares `storage`. A future
+  KinBot release may introduce `ws:<host>:<port>` and the manifest will be
+  updated then.
+
+## Internals
+
+- `wsClient.ts` — singleton WebSocket client (one per `wsUrl`) with:
+  - Exponential reconnect (jittered, capped by `reconnectMaxBackoffMs`).
+  - `command_id`-correlated request/response with 10 s timeout.
+  - Smart handling of the two-phase responses ts-bot emits for `get_status`,
+    `move_channel`, and `send_message` (placeholder ack → final response).
+  - Broadcast event fan-out (multiple consumers can subscribe to event types).
+- `index.ts` — plugin entry; wires the channel adapter, the tools, and a
+  local cache of channels/clients/own_client_id maintained from
+  `client_connected/disconnected/moved` plus periodic `get_status` refreshes.
+
+## Roadmap
+
+- [ ] Auto-create / update KinBot contacts from `sender_uid` + `sender_name`.
+- [ ] Smarter chat filtering (wake-word / mention detection on chat side).
+- [ ] Forward `connection_status` events as KinBot system notifications.
+- [ ] Optionally relay `client_connected` / `client_disconnected` to the Kin
+      as system messages for greetings.
+- [ ] Populate `metadata.present` reliably (currently empty until the local
+      cache is seeded by the second `get_status` response — minor bug to fix
+      in `wsClient.ts` two-phase response handling for the *initial* state
+      query).
+- [ ] Cover the additional ts-bot commands as plugin tools when relevant
+      (`poke_client`, `set_nickname`, `create_channel`, etc.).
+- [ ] Live integration tests against a running ts-bot.

--- a/plugins/teamspeak/README.md
+++ b/plugins/teamspeak/README.md
@@ -8,19 +8,36 @@ It contributes:
   when wake-word transcription is enabled in ts-bot, voice transcriptions) and
   routes outgoing replies to **chat + TTS** following these rules:
   - Private message → chat only (no TTS).
-  - Public channel → TTS only. **ts-bot already echoes the spoken text to the
-    channel chat automatically** (so muted users can read it), so the plugin
-    does NOT send a duplicate chat copy on this path.
-  - Reply longer than `ttsMaxChars` → full text sent explicitly to chat +
-    short TTS notice ("J'ai répondu en chat..."); ts-bot will additionally
-    echo that short notice to chat.
-  - When `enableTtsOnPublic = false`, public replies fall back to chat only.
-- **Tools** (auto-namespaced as `plugin_teamspeak_*` by KinBot):
-  - `get_status` — list channels & clients, show the bot's current location.
+  - Public channel → TTS **and** chat copy (TTS is sometimes glitchy, scrollback is useful).
+  - Reply longer than `ttsMaxChars` → short TTS notice + full text in chat.
+- **16 tools** (auto-namespaced as `plugin_teamspeak_*` by KinBot) covering
+  the full ts-bot WebSocket admin surface:
+
+  Bot voice & chat:
   - `speak` — force TTS playback in the bot's current channel.
+  - `stop_speaking` — interrupt ongoing TTS.
   - `send_chat` — send a chat message to the channel or a private user.
   - `move_channel` — move the bot to another channel.
-  - `stop_speaking` — interrupt ongoing TTS.
+  - `set_nickname` — change the bot's own display nickname.
+
+  Discovery:
+  - `get_status` — list channels & clients, show the bot's current location.
+  - `get_server_info` — TS3 virtual server metadata (name, welcome message, version, …).
+
+  Client moderation:
+  - `poke_client` — send a popup notification to a client.
+  - `kick_client` — kick a client from the channel or the server.
+  - `move_client` — move another client to a specific channel.
+
+  Channel admin:
+  - `create_channel` — create a (optionally temporary) channel with topic / description / password.
+  - `set_channel_description` — update an existing channel's description.
+  - `delete_channel` — delete a channel (`force=true` to evict clients first).
+
+  Voice listening (Whisper STT):
+  - `activate_listener` — start transcribing voice from a specific client.
+  - `deactivate_listener` — stop transcribing voice from that client.
+  - `set_language` — override the STT language per client (ISO 639-1 code or `"auto"`).
 
 ## Requirements
 
@@ -85,19 +102,11 @@ Voice messages additionally include `transcription = { confidence, language, dur
   the voice side; chat filtering will be refined later.
 - **No native message IDs.** TeamSpeak chat has no per-message identifier, so
   the plugin synthesizes UUIDs for `platformMessageId`.
-- The `sender_uid` from ts-bot arrives as a byte array (not a base64 string
-  as the doc once claimed). The plugin's `normalizeUid` helper accepts both
-  shapes and emits a stable base64 identifier.
-- The `welcome` event is emitted with `nickname` (not `bot_nickname`); the
-  client accepts either for forward compatibility.
-- For `send_message` with `target = "private"`, ts-bot expects `recipient` as
-  a **string** (e.g. `"11033"`). The plugin already serializes accordingly.
-- The bot's `wsUrl` is unauthenticated and meant for localhost only. Don't
-  expose it to the public network.
-- **No KinBot `ws:*` permission scheme.** KinBot only enforces `http:<host>`
-  in plugin manifests today, so this plugin only declares `storage`. A future
-  KinBot release may introduce `ws:<host>:<port>` and the manifest will be
-  updated then.
+- The `sender_uid` from ts-bot may arrive as a byte array (observed) rather
+  than the documented base64 string. The plugin normalizes both to a stable
+  base64 identifier.
+- Plugin and ts-bot run on the same host; the WS endpoint is unauthenticated.
+  Don't expose it to the public network.
 
 ## Internals
 
@@ -118,10 +127,4 @@ Voice messages additionally include `transcription = { confidence, language, dur
 - [ ] Forward `connection_status` events as KinBot system notifications.
 - [ ] Optionally relay `client_connected` / `client_disconnected` to the Kin
       as system messages for greetings.
-- [ ] Populate `metadata.present` reliably (currently empty until the local
-      cache is seeded by the second `get_status` response — minor bug to fix
-      in `wsClient.ts` two-phase response handling for the *initial* state
-      query).
-- [ ] Cover the additional ts-bot commands as plugin tools when relevant
-      (`poke_client`, `set_nickname`, `create_channel`, etc.).
 - [ ] Live integration tests against a running ts-bot.

--- a/plugins/teamspeak/README.md
+++ b/plugins/teamspeak/README.md
@@ -10,7 +10,7 @@ It contributes:
   - Private message → chat only (no TTS).
   - Public channel → TTS **and** chat copy (TTS is sometimes glitchy, scrollback is useful).
   - Reply longer than `ttsMaxChars` → short TTS notice + full text in chat.
-- **16 tools** (auto-namespaced as `plugin_teamspeak_*` by KinBot) covering
+- **25 tools** (auto-namespaced as `plugin_teamspeak_*` by KinBot) covering
   the full ts-bot WebSocket admin surface:
 
   Bot voice & chat:
@@ -38,6 +38,15 @@ It contributes:
   - `activate_listener` — start transcribing voice from a specific client.
   - `deactivate_listener` — stop transcribing voice from that client.
   - `set_language` — override the STT language per client (ISO 639-1 code or `"auto"`).
+  - `set_timeout` / `get_timeout` — silence-detection timeout in milliseconds (500-10000).
+
+  Voice / TTS parameters:
+  - `set_volume` / `get_volume` — TTS playback volume (0-200, 100 = normal, 200 = 2× gain).
+  - `set_voice` / `get_voice` — default TTS voice (one of `alloy`, `ash`, `ballad`, `coral`, `echo`, `fable`, `nova`, `onyx`, `sage`, `shimmer`, `verse`).
+  - `set_speed` / `get_speed` — TTS speech speed (0.25-4.0, default 1.15).
+
+  History:
+  - `get_history` — recent conversation entries (chat + transcriptions) tracked by ts-bot. Optional `count` (default 20, max 50).
 
 ## Requirements
 

--- a/plugins/teamspeak/index.test.ts
+++ b/plugins/teamspeak/index.test.ts
@@ -63,6 +63,18 @@ describe('teamspeak plugin export shape', () => {
         'activate_listener',
         'deactivate_listener',
         'set_language',
+        // TTS parameters
+        'set_volume',
+        'get_volume',
+        'set_voice',
+        'get_voice',
+        'set_speed',
+        'get_speed',
+        // STT timeout
+        'set_timeout',
+        'get_timeout',
+        // History
+        'get_history',
       ].sort(),
     )
   })

--- a/plugins/teamspeak/index.test.ts
+++ b/plugins/teamspeak/index.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'bun:test'
+import createPlugin from './index'
+import { normalizeUid } from './wsClient'
+
+function makeCtx(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    config: {
+      wsUrl: 'ws://127.0.0.1:8080/ws',
+      ttsMaxChars: 300,
+      enableTtsOnPublic: true,
+      reconnectMaxBackoffMs: 30000,
+      ...overrides,
+    },
+    log: {
+      debug: () => {},
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+    storage: {
+      get: async () => null,
+      set: async () => {},
+      delete: async () => {},
+      list: async () => [],
+      clear: async () => {},
+    },
+    manifest: { name: 'teamspeak', version: '0.1.0' },
+  }
+}
+
+describe('teamspeak plugin export shape', () => {
+  it('exposes tools, channels, activate and deactivate', () => {
+    const plugin = createPlugin(makeCtx() as any)
+    expect(plugin.tools).toBeDefined()
+    expect(plugin.channels).toBeDefined()
+    expect(typeof plugin.activate).toBe('function')
+    expect(typeof plugin.deactivate).toBe('function')
+  })
+
+  it('declares all expected tools', () => {
+    const plugin = createPlugin(makeCtx() as any)
+    const names = Object.keys(plugin.tools)
+    expect(names.sort()).toEqual(
+      ['get_status', 'move_channel', 'send_chat', 'speak', 'stop_speaking'].sort(),
+    )
+  })
+
+  it('declares the teamspeak channel adapter', () => {
+    const plugin = createPlugin(makeCtx() as any)
+    const adapter = (plugin.channels as Record<string, any>).teamspeak
+    expect(adapter).toBeDefined()
+    expect(adapter.platform).toBe('teamspeak')
+    expect(adapter.meta?.displayName).toBe('TeamSpeak')
+    expect(typeof adapter.start).toBe('function')
+    expect(typeof adapter.stop).toBe('function')
+    expect(typeof adapter.sendMessage).toBe('function')
+    expect(typeof adapter.validateConfig).toBe('function')
+    expect(typeof adapter.getBotInfo).toBe('function')
+  })
+})
+
+describe('normalizeUid', () => {
+  it('passes strings through unchanged', () => {
+    expect(normalizeUid('abc=')).toBe('abc=')
+  })
+  it('converts byte arrays to base64', () => {
+    // "Hi" → 0x48 0x69 → "SGk="
+    expect(normalizeUid([0x48, 0x69])).toBe('SGk=')
+  })
+  it('handles null/undefined safely', () => {
+    expect(normalizeUid(null)).toBe('')
+    expect(normalizeUid(undefined)).toBe('')
+  })
+})

--- a/plugins/teamspeak/index.test.ts
+++ b/plugins/teamspeak/index.test.ts
@@ -41,7 +41,29 @@ describe('teamspeak plugin export shape', () => {
     const plugin = createPlugin(makeCtx() as any)
     const names = Object.keys(plugin.tools)
     expect(names.sort()).toEqual(
-      ['get_status', 'move_channel', 'send_chat', 'speak', 'stop_speaking'].sort(),
+      [
+        'get_status',
+        'move_channel',
+        'send_chat',
+        'speak',
+        'stop_speaking',
+        // Client moderation
+        'poke_client',
+        'kick_client',
+        'move_client',
+        // Bot self-management
+        'set_nickname',
+        // Server info
+        'get_server_info',
+        // Channel admin
+        'create_channel',
+        'set_channel_description',
+        'delete_channel',
+        // Voice listening
+        'activate_listener',
+        'deactivate_listener',
+        'set_language',
+      ].sort(),
     )
   })
 

--- a/plugins/teamspeak/index.ts
+++ b/plugins/teamspeak/index.ts
@@ -1,0 +1,681 @@
+/**
+ * KinBot plugin: teamspeak
+ *
+ * Bridges KinBot to a TeamSpeak server via the local ts-bot WebSocket API
+ * (see /tmp/ts-bot/docs/websocket-api-reference.md for protocol reference).
+ *
+ * Exports:
+ *   - channels.teamspeak  — ChannelAdapter that ingests chat & transcriptions,
+ *     and routes outbound replies to chat / TTS following Nicolas's rules:
+ *       * private message  → chat only (no TTS)
+ *       * public channel   → TTS + chat copy
+ *       * reply > ttsMaxChars → TTS short notice + full text in chat
+ *   - tools.{get_status, speak, send_chat, move_channel, stop_speaking}
+ *
+ * The adapter uses metadata (KinBot ≥ 0.39.0) so the LLM gets full structured
+ * context (modality, presence, channel info) without polluting `content`.
+ */
+
+import { tool } from 'ai'
+import { z } from 'zod'
+import { randomUUID } from 'node:crypto'
+import {
+  getOrCreateClient,
+  disposeClient,
+  normalizeUid,
+  type TsBotWsClient,
+  type TsBotServerState,
+  type TsBotChannel,
+  type TsBotClient,
+  type MessageReceivedEvent,
+  type TranscriptionEvent,
+  type ClientConnectedEvent,
+  type ClientDisconnectedEvent,
+  type ClientMovedEvent,
+  type WelcomeEvent,
+} from './wsClient'
+
+// ─── Plugin context (loose typing to avoid coupling to internal SDK paths) ──
+
+interface PluginCtxLog {
+  debug(msg: string): void
+  debug(obj: Record<string, unknown>, msg: string): void
+  info(msg: string): void
+  info(obj: Record<string, unknown>, msg: string): void
+  warn(msg: string): void
+  warn(obj: Record<string, unknown>, msg: string): void
+  error(msg: string): void
+  error(obj: Record<string, unknown>, msg: string): void
+}
+
+interface PluginCtxStorage {
+  get<T = unknown>(key: string): Promise<T | null>
+  set<T = unknown>(key: string, value: T): Promise<void>
+  delete(key: string): Promise<void>
+  list(prefix?: string): Promise<string[]>
+  clear(): Promise<void>
+}
+
+interface PluginCtx {
+  config: Record<string, unknown>
+  log: PluginCtxLog
+  storage: PluginCtxStorage
+  manifest: { name: string; version: string }
+}
+
+// ─── Config helpers ─────────────────────────────────────────────────────────
+
+interface ResolvedConfig {
+  wsUrl: string
+  defaultVoice?: string
+  ttsMaxChars: number
+  enableTtsOnPublic: boolean
+  ttsTooLongNotice: string
+  reconnectMaxBackoffMs: number
+}
+
+function resolveConfig(raw: Record<string, unknown>): ResolvedConfig {
+  return {
+    wsUrl: (raw.wsUrl as string) || 'ws://127.0.0.1:8080/ws',
+    defaultVoice: (raw.defaultVoice as string) || undefined,
+    ttsMaxChars: typeof raw.ttsMaxChars === 'number' ? raw.ttsMaxChars : 300,
+    enableTtsOnPublic: typeof raw.enableTtsOnPublic === 'boolean' ? raw.enableTtsOnPublic : true,
+    ttsTooLongNotice:
+      (raw.ttsTooLongNotice as string) ||
+      "J'ai répondu en chat, c'était trop long pour le vocal.",
+    reconnectMaxBackoffMs:
+      typeof raw.reconnectMaxBackoffMs === 'number' ? raw.reconnectMaxBackoffMs : 30000,
+  }
+}
+
+// ─── Local state cache (channels, clients, own_client_id) ───────────────────
+
+interface CachedState {
+  ownClientId: number | null
+  channels: Map<number, TsBotChannel>
+  clients: Map<number, TsBotClient>
+  /** Last known client UIDs we logged as "new" (in-memory only, dedup logs) */
+  knownSenderUids: Set<string>
+  /** Last welcome */
+  welcome: WelcomeEvent | null
+}
+
+function emptyState(): CachedState {
+  return {
+    ownClientId: null,
+    channels: new Map(),
+    clients: new Map(),
+    knownSenderUids: new Set(),
+    welcome: null,
+  }
+}
+
+function applyServerState(state: CachedState, payload: TsBotServerState): void {
+  state.ownClientId = payload.own_client_id
+  state.channels.clear()
+  for (const ch of payload.channels) state.channels.set(ch.id, ch)
+  state.clients.clear()
+  for (const cl of payload.clients) state.clients.set(cl.id, cl)
+}
+
+function botLocation(state: CachedState): { channel_id: number | null; channel_name: string | null } {
+  if (state.ownClientId == null) return { channel_id: null, channel_name: null }
+  const me = state.clients.get(state.ownClientId)
+  if (!me) return { channel_id: null, channel_name: null }
+  const ch = state.channels.get(me.channel_id)
+  return { channel_id: me.channel_id, channel_name: ch?.name ?? null }
+}
+
+function presentInChannel(state: CachedState, channelId: number, excludeBot = true): Array<{ id: number; name: string }> {
+  const out: Array<{ id: number; name: string }> = []
+  for (const cl of state.clients.values()) {
+    if (cl.channel_id !== channelId) continue
+    if (excludeBot && state.ownClientId != null && cl.id === state.ownClientId) continue
+    out.push({ id: cl.id, name: cl.name })
+  }
+  return out
+}
+
+// ─── Chat ID encoding ───────────────────────────────────────────────────────
+// We encode the platformChatId as `channel:<id>` for public channels and
+// `private:<sender_id>` for private messages. The adapter parses this back
+// when sending replies. Keeping the sender_id (numeric session ID) in the
+// chatId lets us send private replies via `send_message { target:'user', recipient:N }`.
+
+function encodeChannelChatId(channelId: number): string {
+  return `channel:${channelId}`
+}
+function encodePrivateChatId(senderId: number): string {
+  return `private:${senderId}`
+}
+function parseChatId(chatId: string): { kind: 'channel' | 'private'; id: number } | null {
+  const m = /^(channel|private):(\d+)$/.exec(chatId)
+  if (!m) return null
+  return { kind: m[1] as 'channel' | 'private', id: Number(m[2]) }
+}
+
+// ─── Plugin entry point ─────────────────────────────────────────────────────
+
+export default function (ctx: PluginCtx) {
+  const cfg = resolveConfig(ctx.config)
+  const state = emptyState()
+  let client: TsBotWsClient | null = null
+
+  // Channel adapter — only one TS server per KinBot install for the POC, so we
+  // bind the singleton to whatever channel KinBot starts.
+  let activeChannelId: string | null = null
+  let onMessage: ((m: import('@/server/channels/adapter').IncomingMessage) => Promise<void>) | null = null
+
+  // Restore last own_client_id from storage (purely informational, refresh on connect)
+  const restoreOwnId = async (): Promise<void> => {
+    try {
+      const v = await ctx.storage.get<number>('lastOwnClientId')
+      if (typeof v === 'number') {
+        ctx.log.debug({ lastOwnClientId: v }, 'Restored last own_client_id from storage')
+      }
+    } catch { /* ignore */ }
+  }
+
+  const persistOwnId = async (): Promise<void> => {
+    if (state.ownClientId != null) {
+      try { await ctx.storage.set('lastOwnClientId', state.ownClientId) } catch { /* ignore */ }
+    }
+  }
+
+  // Refresh local state via get_status
+  const refreshState = async (): Promise<void> => {
+    if (!client) return
+    try {
+      const resp = await client.sendCommand<TsBotServerState>(
+        { type: 'get_status' },
+        { expectIntermediate: true },
+      )
+      if (resp.success && resp.data && typeof resp.data === 'object') {
+        applyServerState(state, resp.data as TsBotServerState)
+        await persistOwnId()
+        ctx.log.info(
+          {
+            own_client_id: state.ownClientId,
+            channels: state.channels.size,
+            clients: state.clients.size,
+          },
+          'ts-bot state refreshed',
+        )
+      } else {
+        ctx.log.warn({ resp }, 'get_status returned no data')
+      }
+    } catch (err) {
+      ctx.log.warn({ err: String(err) }, 'Failed to refresh ts-bot state')
+    }
+  }
+
+  // ─── Incoming events → IncomingMessage ───────────────────────────────────
+
+  const buildContextForMessage = (
+    senderId: number,
+    senderName: string,
+    senderUidB64: string,
+    isPrivate: boolean,
+    channelId: number | null,
+    channelName: string | null,
+    modality: 'text' | 'voice',
+  ): Record<string, unknown> => {
+    const present = !isPrivate && channelId != null ? presentInChannel(state, channelId, true) : null
+    return {
+      modality,
+      chatType: isPrivate ? 'private' : 'public_channel',
+      channel: isPrivate ? null : { id: channelId, name: channelName },
+      sender: { uid: senderUidB64, name: senderName, session_id: senderId },
+      present,
+      bot: botLocation(state),
+    }
+  }
+
+  const handleMessageReceived = async (ev: MessageReceivedEvent): Promise<void> => {
+    if (!onMessage || !activeChannelId) return
+    const senderUidB64 = normalizeUid(ev.sender_uid)
+    if (!senderUidB64) {
+      ctx.log.warn({ ev: { sender_id: ev.sender_id, sender_name: ev.sender_name } }, 'message_received without resolvable sender_uid; skipping')
+      return
+    }
+    if (!state.knownSenderUids.has(senderUidB64)) {
+      state.knownSenderUids.add(senderUidB64)
+      ctx.log.info({ uid: senderUidB64, name: ev.sender_name }, 'new sender detected')
+    }
+
+    const isPrivate = ev.message_type === 'private'
+    const chatId = isPrivate ? encodePrivateChatId(ev.sender_id) : encodeChannelChatId(ev.channel_id ?? 0)
+    const metadata = buildContextForMessage(
+      ev.sender_id,
+      ev.sender_name,
+      senderUidB64,
+      isPrivate,
+      ev.channel_id,
+      ev.channel_name,
+      'text',
+    )
+
+    try {
+      await onMessage({
+        platformUserId: senderUidB64,
+        platformDisplayName: ev.sender_name,
+        platformMessageId: randomUUID(),
+        platformChatId: chatId,
+        content: ev.content,
+        metadata,
+      })
+    } catch (err) {
+      ctx.log.error({ err: String(err) }, 'onMessage handler threw')
+    }
+  }
+
+  const handleTranscription = async (ev: TranscriptionEvent): Promise<void> => {
+    if (!onMessage || !activeChannelId) return
+    const speakerUidB64 = normalizeUid(ev.speaker_uid)
+    if (!speakerUidB64) return
+    if (!state.knownSenderUids.has(speakerUidB64)) {
+      state.knownSenderUids.add(speakerUidB64)
+      ctx.log.info({ uid: speakerUidB64, name: ev.speaker_name }, 'new sender detected (voice)')
+    }
+
+    // Voice always lives in the bot's current channel.
+    const loc = botLocation(state)
+    const channelId = loc.channel_id ?? 0
+    const chatId = encodeChannelChatId(channelId)
+    const metadata = buildContextForMessage(
+      ev.speaker_id,
+      ev.speaker_name,
+      speakerUidB64,
+      false,
+      channelId,
+      loc.channel_name,
+      'voice',
+    )
+    // Add transcription-specific extras
+    ;(metadata as Record<string, unknown>).transcription = {
+      confidence: ev.confidence,
+      language: ev.language,
+      duration_ms: ev.duration_ms,
+    }
+
+    try {
+      await onMessage({
+        platformUserId: speakerUidB64,
+        platformDisplayName: ev.speaker_name,
+        platformMessageId: randomUUID(),
+        platformChatId: chatId,
+        content: ev.text,
+        metadata,
+      })
+    } catch (err) {
+      ctx.log.error({ err: String(err) }, 'onMessage handler threw (voice)')
+    }
+  }
+
+  // Local cache mutations for client lifecycle events
+  const handleClientConnected = (ev: ClientConnectedEvent): void => {
+    state.clients.set(ev.client_id, {
+      id: ev.client_id,
+      name: ev.client_name,
+      channel_id: ev.channel_id,
+      uid: ev.uid,
+    })
+  }
+  const handleClientDisconnected = (ev: ClientDisconnectedEvent): void => {
+    state.clients.delete(ev.client_id)
+  }
+  const handleClientMoved = (ev: ClientMovedEvent): void => {
+    const existing = state.clients.get(ev.client_id)
+    if (existing) {
+      existing.channel_id = ev.new_channel_id
+    } else {
+      state.clients.set(ev.client_id, {
+        id: ev.client_id,
+        name: ev.client_name,
+        channel_id: ev.new_channel_id,
+        uid: ev.uid,
+      })
+    }
+    if (state.ownClientId != null && ev.client_id === state.ownClientId) {
+      void persistOwnId()
+    }
+  }
+
+  // ─── ChannelAdapter implementation ───────────────────────────────────────
+
+  const adapter = {
+    platform: 'teamspeak',
+    meta: {
+      displayName: 'TeamSpeak',
+      brandColor: '#2580C3',
+    },
+
+    async start(
+      channelId: string,
+      channelConfig: Record<string, unknown>,
+      msgHandler: (m: import('@/server/channels/adapter').IncomingMessage) => Promise<void>,
+    ): Promise<void> {
+      // The plugin is configured at plugin level, not per-channel. We use the
+      // plugin config but also let the channel override wsUrl if it wants.
+      const url = (channelConfig?.wsUrl as string) || cfg.wsUrl
+      activeChannelId = channelId
+      onMessage = msgHandler
+
+      client = getOrCreateClient({
+        url,
+        log: ctx.log,
+        reconnectMaxBackoffMs: cfg.reconnectMaxBackoffMs,
+      })
+
+      // Wire listeners
+      client.on('message_received', (ev) => { void handleMessageReceived(ev as MessageReceivedEvent) })
+      client.on('transcription', (ev) => { void handleTranscription(ev as TranscriptionEvent) })
+      client.on('client_connected', (ev) => handleClientConnected(ev as ClientConnectedEvent))
+      client.on('client_disconnected', (ev) => handleClientDisconnected(ev as ClientDisconnectedEvent))
+      client.on('client_moved', (ev) => handleClientMoved(ev as ClientMovedEvent))
+      client.on('welcome', (ev) => {
+        state.welcome = ev as WelcomeEvent
+        // Fresh connection → refresh state
+        void refreshState()
+      })
+
+      await restoreOwnId()
+      // Fire & forget: open WS and refresh state once connected
+      try {
+        await client.start(false, 5000)
+        await refreshState()
+      } catch (err) {
+        ctx.log.warn({ err: String(err), url }, 'Initial ts-bot connection failed; will keep retrying')
+      }
+
+      ctx.log.info({ channelId, url }, 'teamspeak channel started')
+    },
+
+    async stop(channelId: string): Promise<void> {
+      if (channelId !== activeChannelId) {
+        ctx.log.warn({ channelId, activeChannelId }, 'stop() called for unknown teamspeak channelId')
+      }
+      activeChannelId = null
+      onMessage = null
+      // Keep the WS client alive if other consumers (tools) might still want it.
+      // For the POC we tear it down to keep semantics clean.
+      if (client) {
+        disposeClient(cfg.wsUrl)
+        client = null
+      }
+      ctx.log.info({ channelId }, 'teamspeak channel stopped')
+    },
+
+    async sendMessage(
+      _channelId: string,
+      _channelConfig: Record<string, unknown>,
+      params: { chatId: string; content: string; replyToMessageId?: string },
+    ): Promise<{ platformMessageId: string }> {
+      const parsed = parseChatId(params.chatId)
+      if (!parsed) throw new Error(`Invalid teamspeak chatId: ${params.chatId}`)
+
+      if (!client) throw new Error('teamspeak adapter not started (no WS client)')
+
+      const text = (params.content ?? '').trim()
+      if (!text) {
+        // Nothing to send — return a synthetic ID so the caller doesn't choke.
+        return { platformMessageId: randomUUID() }
+      }
+
+      const isPrivate = parsed.kind === 'private'
+
+      // Always send chat copy. For private MPs target the user, otherwise the
+      // current channel of the bot.
+      const sendChat = async (content: string): Promise<void> => {
+        const cmd: Record<string, unknown> = isPrivate
+          ? { type: 'send_message', target: 'user', recipient: parsed.id, content }
+          : { type: 'send_message', target: 'channel', content }
+        await client!.sendCommand(cmd, { expectIntermediate: true })
+      }
+
+      const sendTts = async (content: string): Promise<void> => {
+        const cmd: Record<string, unknown> = { type: 'speak', text: content }
+        if (cfg.defaultVoice) cmd.voice = cfg.defaultVoice
+        await client!.sendCommand(cmd, { expectIntermediate: false })
+      }
+
+      try {
+        if (isPrivate) {
+          // Private → chat only
+          await sendChat(text)
+        } else {
+          // Public channel → ts-bot already echoes TTS to channel chat
+          // automatically (see ts-bot main.rs: "Echo TTS text to TS3 channel
+          // chat so muted users can read it"). So we don't duplicate the
+          // chat copy ourselves on the TTS path.
+          if (cfg.enableTtsOnPublic) {
+            const tooLong = cfg.ttsMaxChars > 0 && text.length > cfg.ttsMaxChars
+            if (tooLong) {
+              // Full text via explicit chat (since the TTS notice differs)
+              // + short voice notice (which ts-bot will also echo to chat).
+              await sendChat(text).catch((e) => {
+                ctx.log.warn({ err: String(e) }, 'chat send failed (long-reply path)')
+              })
+              await sendTts(cfg.ttsTooLongNotice).catch((e) => {
+                ctx.log.warn({ err: String(e) }, 'TTS short-notice failed')
+              })
+            } else {
+              // Speak full text — ts-bot echoes it to channel chat itself.
+              await sendTts(text).catch((e) => {
+                ctx.log.warn({ err: String(e) }, 'TTS send failed')
+              })
+            }
+          } else {
+            // TTS disabled by config → explicit chat only
+            await sendChat(text)
+          }
+        }
+      } catch (err) {
+        ctx.log.error({ err: String(err), chatId: params.chatId }, 'sendMessage failed')
+        throw err
+      }
+
+      // We don't have a real platform message ID — synthesize one.
+      return { platformMessageId: randomUUID() }
+    },
+
+    async validateConfig(channelConfig: Record<string, unknown>): Promise<{ valid: boolean; error?: string }> {
+      const url = (channelConfig?.wsUrl as string) || cfg.wsUrl
+      try {
+        const { TsBotWsClient } = await import('./wsClient')
+        const transient = new TsBotWsClient({ url, log: ctx.log })
+        const welcome = await transient.start(true, 5000)
+        transient.stop()
+        if (welcome && welcome.type === 'welcome') return { valid: true }
+        return { valid: false, error: 'No welcome event received' }
+      } catch (err) {
+        return { valid: false, error: err instanceof Error ? err.message : String(err) }
+      }
+    },
+
+    async getBotInfo(channelConfig: Record<string, unknown>): Promise<{ name: string; username?: string } | null> {
+      const url = (channelConfig?.wsUrl as string) || cfg.wsUrl
+      try {
+        const transient = new (await import('./wsClient')).TsBotWsClient({ url, log: ctx.log })
+        const welcome = await transient.start(true, 5000)
+        transient.stop()
+        const name = welcome.nickname ?? welcome.bot_nickname ?? 'TeamSpeak Bot'
+        return { name }
+      } catch (err) {
+        ctx.log.warn({ err: String(err), url }, 'getBotInfo failed')
+        return null
+      }
+    },
+  }
+
+  // ─── Tools ───────────────────────────────────────────────────────────────
+  // These are namespaced as `plugin_teamspeak_*` automatically by KinBot.
+
+  const ensureClient = (): TsBotWsClient => {
+    if (!client) {
+      // Lazy-init a client purely for tool use, even if no channel is bound.
+      client = getOrCreateClient({
+        url: cfg.wsUrl,
+        log: ctx.log,
+        reconnectMaxBackoffMs: cfg.reconnectMaxBackoffMs,
+      })
+      // Best-effort start; tools will fail if WS isn't up.
+      void client.start(false, 5000).catch((err) => {
+        ctx.log.warn({ err: String(err) }, 'lazy ts-bot client start failed')
+      })
+    }
+    return client
+  }
+
+  const tools = {
+    get_status: {
+      availability: ['main', 'sub-kin'] as const,
+      create: () =>
+        tool({
+          description:
+            'Get the current TeamSpeak server state via the ts-bot bridge: list of channels, list of connected clients, and the bot\'s current location.',
+          inputSchema: z.object({}),
+          execute: async () => {
+            const c = ensureClient()
+            const resp = await c.sendCommand<TsBotServerState>(
+              { type: 'get_status' },
+              { expectIntermediate: true },
+            )
+            if (!resp.success || !resp.data) {
+              return { error: resp.message ?? 'get_status failed' }
+            }
+            applyServerState(state, resp.data as TsBotServerState)
+            await persistOwnId()
+            const loc = botLocation(state)
+            return {
+              own_client_id: state.ownClientId,
+              bot: loc,
+              channels: Array.from(state.channels.values()).map((ch) => ({
+                id: ch.id,
+                name: ch.name,
+                parent_id: ch.parent_id,
+              })),
+              clients: Array.from(state.clients.values()).map((cl) => ({
+                id: cl.id,
+                name: cl.name,
+                channel_id: cl.channel_id,
+                uid: cl.uid,
+              })),
+            }
+          },
+        }),
+    },
+
+    speak: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Force TTS playback in the bot\'s current TeamSpeak channel. The text is queued and replaces any ongoing playback.',
+          inputSchema: z.object({
+            text: z.string().min(1).max(2000).describe('Text to synthesize (≤ 2000 chars).'),
+            voice: z.string().optional().describe('Optional voice identifier. Falls back to plugin defaultVoice or server default.'),
+          }),
+          execute: async ({ text, voice }) => {
+            const c = ensureClient()
+            const cmd: Record<string, unknown> = { type: 'speak', text }
+            const v = voice ?? cfg.defaultVoice
+            if (v) cmd.voice = v
+            const resp = await c.sendCommand(cmd, { expectIntermediate: false })
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    send_chat: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Send a text chat message to TeamSpeak. By default sends to the bot\'s current channel. Set target="user" with recipient=<client_id> to send a private message.',
+          inputSchema: z.object({
+            text: z.string().min(1).max(8192).describe('Message body (≤ 8192 chars).'),
+            target: z.enum(['channel', 'user']).default('channel').describe('"channel" (current channel chat) or "user" (private message).'),
+            recipient: z
+              .number()
+              .int()
+              .positive()
+              .optional()
+              .describe('Required when target="user": session client ID of the recipient (use get_status to find it).'),
+          }),
+          execute: async ({ text, target, recipient }) => {
+            const c = ensureClient()
+            if (target === 'user' && (recipient == null || recipient <= 0)) {
+              return { error: 'recipient (positive client id) is required when target="user"' }
+            }
+            const cmd: Record<string, unknown> =
+              target === 'user'
+                ? { type: 'send_message', target: 'user', recipient, content: text }
+                : { type: 'send_message', target: 'channel', content: text }
+            const resp = await c.sendCommand(cmd, { expectIntermediate: true })
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    move_channel: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description: 'Move the TeamSpeak bot to a different channel. Use get_status to discover channel IDs.',
+          inputSchema: z.object({
+            channel_id: z.number().int().positive().describe('Target channel ID (> 0).'),
+            password: z.string().optional().describe('Channel password if required.'),
+          }),
+          execute: async ({ channel_id, password }) => {
+            const c = ensureClient()
+            const cmd: Record<string, unknown> = { type: 'move_channel', channel_id }
+            if (password) cmd.password = password
+            const resp = await c.sendCommand(cmd, { expectIntermediate: true })
+            // After a move, refresh state in the background
+            void refreshState()
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    stop_speaking: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description: 'Immediately stop any ongoing TTS playback in the TeamSpeak channel. No-op if nothing is playing.',
+          inputSchema: z.object({}),
+          execute: async () => {
+            const c = ensureClient()
+            const resp = await c.sendCommand({ type: 'stop_speaking' }, { expectIntermediate: false })
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+  }
+
+  return {
+    channels: { teamspeak: adapter },
+    tools,
+
+    async activate(): Promise<void> {
+      ctx.log.info(
+        {
+          wsUrl: cfg.wsUrl,
+          enableTtsOnPublic: cfg.enableTtsOnPublic,
+          ttsMaxChars: cfg.ttsMaxChars,
+          defaultVoice: cfg.defaultVoice ?? null,
+        },
+        'teamspeak plugin activated',
+      )
+    },
+
+    async deactivate(): Promise<void> {
+      try { disposeClient(cfg.wsUrl) } catch { /* ignore */ }
+      client = null
+      activeChannelId = null
+      onMessage = null
+      ctx.log.info('teamspeak plugin deactivated')
+    },
+  }
+}

--- a/plugins/teamspeak/index.ts
+++ b/plugins/teamspeak/index.ts
@@ -652,6 +652,240 @@ export default function (ctx: PluginCtx) {
           },
         }),
     },
+
+    // ─── Client moderation ────────────────────────────────────────────────
+
+    poke_client: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Send a poke notification (popup) to a specific TS3 client. The recipient sees a modal popup with the message. Use get_status to find client session IDs.',
+          inputSchema: z.object({
+            client_id: z.number().int().positive().describe('Target client session ID (use get_status to discover).'),
+            message: z.string().max(100).optional().describe('Optional poke message (≤ 100 chars; TS3 limit).'),
+          }),
+          execute: async ({ client_id, message }) => {
+            const c = ensureClient()
+            const cmd: Record<string, unknown> = { type: 'poke_client', client_id }
+            if (message) cmd.message = message
+            const resp = await c.sendCommand(cmd, { expectIntermediate: false })
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    kick_client: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Kick a client from the current channel or the entire server. Destructive — applied immediately, no confirmation prompt. Use get_status to find client IDs.',
+          inputSchema: z.object({
+            client_id: z.number().int().positive().describe('Target client session ID.'),
+            reason: z.string().max(255).optional().describe('Reason shown to the kicked client.'),
+            kick_type: z
+              .enum(['channel', 'server'])
+              .optional()
+              .describe('"channel" boots them back to the default channel; "server" disconnects them. Default: "server".'),
+          }),
+          execute: async ({ client_id, reason, kick_type }) => {
+            const c = ensureClient()
+            const cmd: Record<string, unknown> = { type: 'kick_client', client_id }
+            if (reason) cmd.reason = reason
+            if (kick_type) cmd.kick_type = kick_type
+            const resp = await c.sendCommand(cmd, { expectIntermediate: false })
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    move_client: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Move another client to a specific channel. (To move the bot itself, use move_channel.) Use get_status to discover client and channel IDs.',
+          inputSchema: z.object({
+            client_id: z.number().int().positive().describe('Client session ID to move.'),
+            channel_id: z.number().int().positive().describe('Destination channel ID (> 0).'),
+            password: z.string().optional().describe('Channel password if required.'),
+          }),
+          execute: async ({ client_id, channel_id, password }) => {
+            const c = ensureClient()
+            const cmd: Record<string, unknown> = { type: 'move_client', client_id, channel_id }
+            if (password) cmd.password = password
+            const resp = await c.sendCommand(cmd, { expectIntermediate: true })
+            void refreshState()
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    // ─── Bot self-management ──────────────────────────────────────────────
+
+    set_nickname: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description: "Change the bot's own display nickname on TeamSpeak. The new name is visible to everyone immediately.",
+          inputSchema: z.object({
+            nickname: z.string().min(1).max(30).describe('New nickname (1-30 chars; TS3 limit).'),
+          }),
+          execute: async ({ nickname }) => {
+            const c = ensureClient()
+            const resp = await c.sendCommand({ type: 'set_nickname', nickname }, { expectIntermediate: false })
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    // ─── Server info ──────────────────────────────────────────────────────
+
+    get_server_info: {
+      availability: ['main', 'sub-kin'] as const,
+      create: () =>
+        tool({
+          description: 'Get TS3 virtual server metadata (name, welcome message, version, max clients, etc.).',
+          inputSchema: z.object({}),
+          execute: async () => {
+            const c = ensureClient()
+            const resp = await c.sendCommand({ type: 'get_server_info' }, { expectIntermediate: true })
+            if (!resp.success) return { error: resp.message ?? 'get_server_info failed' }
+            return { success: true, message: resp.message ?? null, data: resp.data ?? null }
+          },
+        }),
+    },
+
+    // ─── Channel admin ────────────────────────────────────────────────────
+
+    create_channel: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Create a new TS3 channel. Optionally make it temporary (auto-deletes when empty), nest it under a parent, or set topic / description / password.',
+          inputSchema: z.object({
+            name: z.string().min(1).max(40).describe('Channel name (1-40 chars; TS3 limit).'),
+            parent_id: z.number().int().nonnegative().optional().describe('Parent channel ID (0 or omit = root).'),
+            temporary: z.boolean().optional().describe('If true, the channel auto-deletes when the last client leaves.'),
+            topic: z.string().max(255).optional().describe('Channel topic (short tagline).'),
+            description: z.string().max(8192).optional().describe('Channel description (long text, ≤ 8192 chars).'),
+            password: z.string().optional().describe('Optional password to restrict access.'),
+          }),
+          execute: async ({ name, parent_id, temporary, topic, description, password }) => {
+            const c = ensureClient()
+            const cmd: Record<string, unknown> = { type: 'create_channel', name }
+            if (parent_id != null) cmd.parent_id = parent_id
+            if (temporary != null) cmd.temporary = temporary
+            if (topic) cmd.topic = topic
+            if (description) cmd.description = description
+            if (password) cmd.password = password
+            const resp = await c.sendCommand(cmd, { expectIntermediate: true })
+            void refreshState()
+            return { success: resp.success, message: resp.message ?? null, data: resp.data ?? null }
+          },
+        }),
+    },
+
+    set_channel_description: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description: "Update an existing channel's description (long text shown in TS3 channel info).",
+          inputSchema: z.object({
+            channel_id: z.number().int().positive().describe('Target channel ID.'),
+            description: z.string().max(8192).describe('New description (≤ 8192 chars). Pass an empty string to clear.'),
+          }),
+          execute: async ({ channel_id, description }) => {
+            const c = ensureClient()
+            const resp = await c.sendCommand(
+              { type: 'set_channel_description', channel_id, description },
+              { expectIntermediate: false },
+            )
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    delete_channel: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Delete a TS3 channel. Destructive — applied immediately, no confirmation prompt. Set force=true to delete even if clients are inside (they will be moved to the default channel).',
+          inputSchema: z.object({
+            channel_id: z.number().int().positive().describe('Channel ID to delete.'),
+            force: z.boolean().optional().describe('If true, delete even when clients are present (they get moved to the default channel). Default: false.'),
+          }),
+          execute: async ({ channel_id, force }) => {
+            const c = ensureClient()
+            const cmd: Record<string, unknown> = { type: 'delete_channel', channel_id }
+            if (force != null) cmd.force = force
+            const resp = await c.sendCommand(cmd, { expectIntermediate: false })
+            void refreshState()
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    // ─── Voice listening (Whisper STT) ────────────────────────────────────
+
+    activate_listener: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description: 'Start transcribing voice from a specific TS3 client (Whisper STT). Audio from that client will start producing transcription events.',
+          inputSchema: z.object({
+            client_id: z.number().int().positive().describe('Client session ID to start listening to.'),
+          }),
+          execute: async ({ client_id }) => {
+            const c = ensureClient()
+            const resp = await c.sendCommand({ type: 'activate_listener', client_id }, { expectIntermediate: false })
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    deactivate_listener: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description: 'Stop transcribing voice from a specific TS3 client. Transcription events for that client will cease.',
+          inputSchema: z.object({
+            client_id: z.number().int().positive().describe('Client session ID to stop listening to.'),
+          }),
+          execute: async ({ client_id }) => {
+            const c = ensureClient()
+            const resp = await c.sendCommand({ type: 'deactivate_listener', client_id }, { expectIntermediate: false })
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    set_language: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Override the language used for STT (Whisper) for a specific client. Pass an ISO 639-1 two-letter code (e.g. "fr", "en", "de") or "auto" to reset to automatic detection.',
+          inputSchema: z.object({
+            client_id: z.number().int().positive().describe('Client session ID.'),
+            language: z
+              .string()
+              .regex(/^([a-z]{2}|auto)$/, 'Must be a lowercase ISO 639-1 two-letter code (e.g. "fr") or "auto".')
+              .describe('ISO 639-1 code (e.g. "fr", "en", "de", "es", "ja") or "auto".'),
+          }),
+          execute: async ({ client_id, language }) => {
+            const c = ensureClient()
+            const resp = await c.sendCommand(
+              { type: 'set_language', client_id, language },
+              { expectIntermediate: false },
+            )
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
   }
 
   return {

--- a/plugins/teamspeak/index.ts
+++ b/plugins/teamspeak/index.ts
@@ -936,23 +936,14 @@ export default function (ctx: PluginCtx) {
       create: () =>
         tool({
           description:
-            'Set the default TTS voice used by ts-bot. Voices are OpenAI TTS voice IDs. Persisted by ts-bot until changed again.',
+            'Set the default TTS voice used by ts-bot. Accepts any voice registered server-side: OpenAI voices (alloy, ash, ballad, coral, echo, fable, nova, onyx, sage, shimmer, verse) and any ElevenLabs voice or cloned voice that ts-bot has loaded at startup (e.g. kartal, jade, edouard...). Validation is performed by ts-bot against its live voice registry; invalid voices return an error message listing the valid ones. Persisted by ts-bot until changed again.',
           inputSchema: z.object({
             voice: z
-              .enum([
-                'alloy',
-                'ash',
-                'ballad',
-                'coral',
-                'echo',
-                'fable',
-                'nova',
-                'onyx',
-                'sage',
-                'shimmer',
-                'verse',
-              ])
-              .describe('Voice name. One of: alloy, ash, ballad, coral, echo, fable, nova, onyx, sage, shimmer, verse.'),
+              .string()
+              .min(1)
+              .describe(
+                'Voice name. OpenAI voices: alloy, ash, ballad, coral, echo, fable, nova, onyx, sage, shimmer, verse. ElevenLabs/cloned voices depend on what ts-bot has loaded (use get_status or ask ts-bot to discover the current list).',
+              ),
           }),
           execute: async ({ voice }) => {
             const c = ensureClient()

--- a/plugins/teamspeak/index.ts
+++ b/plugins/teamspeak/index.ts
@@ -886,6 +886,210 @@ export default function (ctx: PluginCtx) {
           },
         }),
     },
+
+    // ─── TTS parameters: volume ───────────────────────────────────────────
+
+    set_volume: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Set the TTS playback volume on the ts-bot side. 0 = mute, 100 = normal, 200 = 2x gain. Persisted by ts-bot until changed again.',
+          inputSchema: z.object({
+            volume: z
+              .number()
+              .int()
+              .min(0)
+              .max(200)
+              .describe('Volume level 0-200 (100 = normal, 0 = mute, 200 = 2x gain).'),
+          }),
+          execute: async ({ volume }) => {
+            const c = ensureClient()
+            const resp = await c.sendCommand(
+              { type: 'set_volume', volume },
+              { expectIntermediate: false },
+            )
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    get_volume: {
+      availability: ['main', 'sub-kin'] as const,
+      create: () =>
+        tool({
+          description: 'Get the current TTS playback volume (0-200, where 100 = normal).',
+          inputSchema: z.object({}),
+          execute: async () => {
+            const c = ensureClient()
+            const resp = await c.sendCommand({ type: 'get_volume' }, { expectIntermediate: false })
+            if (!resp.success) return { error: resp.message ?? 'get_volume failed' }
+            return { success: true, message: resp.message ?? null, data: resp.data ?? null }
+          },
+        }),
+    },
+
+    // ─── TTS parameters: voice ────────────────────────────────────────────
+
+    set_voice: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Set the default TTS voice used by ts-bot. Voices are OpenAI TTS voice IDs. Persisted by ts-bot until changed again.',
+          inputSchema: z.object({
+            voice: z
+              .enum([
+                'alloy',
+                'ash',
+                'ballad',
+                'coral',
+                'echo',
+                'fable',
+                'nova',
+                'onyx',
+                'sage',
+                'shimmer',
+                'verse',
+              ])
+              .describe('Voice name. One of: alloy, ash, ballad, coral, echo, fable, nova, onyx, sage, shimmer, verse.'),
+          }),
+          execute: async ({ voice }) => {
+            const c = ensureClient()
+            const resp = await c.sendCommand(
+              { type: 'set_voice', voice },
+              { expectIntermediate: false },
+            )
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    get_voice: {
+      availability: ['main', 'sub-kin'] as const,
+      create: () =>
+        tool({
+          description: 'Get the current default TTS voice used by ts-bot.',
+          inputSchema: z.object({}),
+          execute: async () => {
+            const c = ensureClient()
+            const resp = await c.sendCommand({ type: 'get_voice' }, { expectIntermediate: false })
+            if (!resp.success) return { error: resp.message ?? 'get_voice failed' }
+            return { success: true, message: resp.message ?? null, data: resp.data ?? null }
+          },
+        }),
+    },
+
+    // ─── TTS parameters: speed ────────────────────────────────────────────
+
+    set_speed: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Set the TTS speech speed. Range 0.25 (very slow) to 4.0 (very fast); ts-bot default is 1.15. Persisted until changed again.',
+          inputSchema: z.object({
+            speed: z
+              .number()
+              .min(0.25)
+              .max(4.0)
+              .describe('TTS speed (0.25-4.0, default 1.15).'),
+          }),
+          execute: async ({ speed }) => {
+            const c = ensureClient()
+            const resp = await c.sendCommand(
+              { type: 'set_speed', speed },
+              { expectIntermediate: false },
+            )
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    get_speed: {
+      availability: ['main', 'sub-kin'] as const,
+      create: () =>
+        tool({
+          description: 'Get the current TTS speech speed (0.25-4.0).',
+          inputSchema: z.object({}),
+          execute: async () => {
+            const c = ensureClient()
+            const resp = await c.sendCommand({ type: 'get_speed' }, { expectIntermediate: false })
+            if (!resp.success) return { error: resp.message ?? 'get_speed failed' }
+            return { success: true, message: resp.message ?? null, data: resp.data ?? null }
+          },
+        }),
+    },
+
+    // ─── STT silence-detection timeout ────────────────────────────────────
+
+    set_timeout: {
+      availability: ['main'] as const,
+      create: () =>
+        tool({
+          description:
+            'Set the silence-detection timeout (in milliseconds) used by the STT/listener pipeline to decide when a speaker has stopped talking. Range 500-10000 ms.',
+          inputSchema: z.object({
+            timeout_ms: z
+              .number()
+              .int()
+              .min(500)
+              .max(10000)
+              .describe('Silence detection timeout in milliseconds (500-10000).'),
+          }),
+          execute: async ({ timeout_ms }) => {
+            const c = ensureClient()
+            const resp = await c.sendCommand(
+              { type: 'set_timeout', timeout_ms },
+              { expectIntermediate: false },
+            )
+            return { success: resp.success, message: resp.message }
+          },
+        }),
+    },
+
+    get_timeout: {
+      availability: ['main', 'sub-kin'] as const,
+      create: () =>
+        tool({
+          description: 'Get the current STT silence-detection timeout in milliseconds.',
+          inputSchema: z.object({}),
+          execute: async () => {
+            const c = ensureClient()
+            const resp = await c.sendCommand({ type: 'get_timeout' }, { expectIntermediate: false })
+            if (!resp.success) return { error: resp.message ?? 'get_timeout failed' }
+            return { success: true, message: resp.message ?? null, data: resp.data ?? null }
+          },
+        }),
+    },
+
+    // ─── Conversation history ─────────────────────────────────────────────
+
+    get_history: {
+      availability: ['main', 'sub-kin'] as const,
+      create: () =>
+        tool({
+          description:
+            'Fetch the most recent conversation history entries (chat + voice transcriptions) tracked by ts-bot. Optional `count` controls how many entries are returned (default 20, max 50).',
+          inputSchema: z.object({
+            count: z
+              .number()
+              .int()
+              .min(1)
+              .max(50)
+              .optional()
+              .describe('Number of entries to return (default 20, max 50).'),
+          }),
+          execute: async ({ count }) => {
+            const c = ensureClient()
+            const cmd: Record<string, unknown> = { type: 'get_history' }
+            if (count != null) cmd.count = count
+            const resp = await c.sendCommand(cmd, { expectIntermediate: false })
+            if (!resp.success) return { error: resp.message ?? 'get_history failed' }
+            return { success: true, message: resp.message ?? null, data: resp.data ?? null }
+          },
+        }),
+    },
   }
 
   return {

--- a/plugins/teamspeak/plugin.json
+++ b/plugins/teamspeak/plugin.json
@@ -1,0 +1,60 @@
+{
+  "name": "teamspeak",
+  "version": "0.1.0",
+  "description": "Bridge KinBot with a TeamSpeak server via the local ts-bot WebSocket API. Adds a 'teamspeak' channel adapter (chat + TTS) and tools to control the bot (move, speak, send chat, status).",
+  "author": "MarlBurroW",
+  "license": "MIT",
+  "main": "index.ts",
+  "icon": "🎙️",
+  "kinbot": ">=0.39.0",
+  "tags": ["teamspeak", "voice", "chat", "tts", "channel"],
+  "permissions": [
+    "storage"
+  ],
+  "config": {
+    "wsUrl": {
+      "type": "string",
+      "label": "ts-bot WebSocket URL",
+      "description": "URL of the local ts-bot WebSocket endpoint. Default: ws://127.0.0.1:8080/ws",
+      "default": "ws://127.0.0.1:8080/ws",
+      "placeholder": "ws://127.0.0.1:8080/ws",
+      "required": true
+    },
+    "defaultVoice": {
+      "type": "string",
+      "label": "Default TTS voice (optional)",
+      "description": "Voice identifier passed to the TTS pipeline (e.g. ff_siwis). Leave empty to use the ts-bot server default.",
+      "placeholder": "ff_siwis"
+    },
+    "ttsMaxChars": {
+      "type": "number",
+      "label": "TTS soft limit (chars)",
+      "description": "Replies longer than this are truncated to a short voice notice; the full text is sent to chat. Set to 0 to disable the limit.",
+      "default": 300,
+      "min": 0,
+      "max": 2000,
+      "step": 10
+    },
+    "enableTtsOnPublic": {
+      "type": "boolean",
+      "label": "Speak replies in public channels",
+      "description": "When ON, public channel replies are spoken AND copied to chat. When OFF, public channel replies are chat-only. Private messages are always chat-only.",
+      "default": true
+    },
+    "ttsTooLongNotice": {
+      "type": "string",
+      "label": "TTS truncation notice",
+      "description": "Short sentence spoken when the reply is too long for TTS. The full text is sent to chat as well.",
+      "default": "J'ai répondu en chat, c'était trop long pour le vocal."
+    },
+    "reconnectMaxBackoffMs": {
+      "type": "number",
+      "label": "Max reconnect backoff (ms)",
+      "description": "Upper bound for exponential reconnect backoff to the ts-bot WebSocket.",
+      "default": 30000,
+      "min": 1000,
+      "max": 300000,
+      "step": 1000
+    }
+  }
+}

--- a/plugins/teamspeak/wsClient.ts
+++ b/plugins/teamspeak/wsClient.ts
@@ -1,0 +1,552 @@
+/**
+ * ts-bot WebSocket client helper.
+ *
+ * - One singleton client per (wsUrl) — multiple consumers (channel adapter + tools)
+ *   share the same connection.
+ * - Broadcast model: every connected WS client sees every event. We correlate
+ *   command responses by `command_id`.
+ * - Auto-reconnect with exponential backoff (capped). Listeners survive
+ *   reconnects.
+ * - Promises for commands time out after 10s.
+ */
+
+import { randomUUID } from 'node:crypto'
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface TsBotChannel {
+  id: number
+  name: string
+  parent_id: number
+  // ts-bot returns more fields (codec, order, topic, etc.) — we keep them as-is.
+  [k: string]: unknown
+}
+
+export interface TsBotClient {
+  id: number
+  name: string
+  channel_id: number
+  uid?: string
+  [k: string]: unknown
+}
+
+export interface TsBotServerState {
+  own_client_id: number
+  channels: TsBotChannel[]
+  clients: TsBotClient[]
+}
+
+export interface WelcomeEvent {
+  type: 'welcome'
+  /** Documented as `bot_nickname` but the Rust enum serializes as `nickname`. We accept both. */
+  nickname?: string
+  bot_nickname?: string
+  server?: string
+  ts3_server?: string
+  api_version: string
+  connection_status: string
+}
+
+export interface CommandResponseEvent {
+  type: 'command_response'
+  command_id: string | null
+  success: boolean
+  message?: string
+  data?: unknown
+}
+
+export interface MessageReceivedEvent {
+  type: 'message_received'
+  timestamp: string
+  sender_id: number
+  /** Real payload is a byte array (e.g. [54,85,...]); doc says base64 string. We accept both. */
+  sender_uid: number[] | string
+  sender_name: string
+  message_type: 'channel' | 'private'
+  content: string
+  channel_id: number | null
+  channel_name: string | null
+}
+
+export interface TranscriptionEvent {
+  type: 'transcription'
+  timestamp: string
+  speaker_id: number
+  speaker_uid: number[] | string
+  speaker_name: string
+  text: string
+  confidence: number | null
+  language: string | null
+  duration_ms: number
+}
+
+export interface ConnectionStatusEvent {
+  type: 'connection_status'
+  status: 'connected' | 'disconnected' | 'reconnecting'
+  server?: string
+  channel_id?: number | null
+  channel_name?: string | null
+  error?: string | null
+}
+
+export interface ClientConnectedEvent {
+  type: 'client_connected'
+  client_id: number
+  client_name: string
+  channel_id: number
+  uid?: string
+}
+
+export interface ClientDisconnectedEvent {
+  type: 'client_disconnected'
+  client_id: number
+  client_name: string
+  uid?: string
+}
+
+export interface ClientMovedEvent {
+  type: 'client_moved'
+  client_id: number
+  client_name: string
+  old_channel_id: number
+  new_channel_id: number
+  old_channel_name?: string | null
+  new_channel_name?: string | null
+  uid?: string
+}
+
+export interface SpeakStartedEvent {
+  type: 'speak_started'
+  text: string
+}
+
+export interface SpeakCompletedEvent {
+  type: 'speak_completed'
+  text: string
+  duration_ms: number
+  success?: boolean
+  error?: string | null
+}
+
+export type TsBotEvent =
+  | WelcomeEvent
+  | CommandResponseEvent
+  | MessageReceivedEvent
+  | TranscriptionEvent
+  | ConnectionStatusEvent
+  | ClientConnectedEvent
+  | ClientDisconnectedEvent
+  | ClientMovedEvent
+  | SpeakStartedEvent
+  | SpeakCompletedEvent
+  | { type: string;[k: string]: unknown }
+
+export type EventType = TsBotEvent['type']
+
+export type EventHandler<E extends TsBotEvent = TsBotEvent> = (event: E) => void
+
+export interface PluginLogger {
+  debug(msg: string): void
+  debug(obj: Record<string, unknown>, msg: string): void
+  info(msg: string): void
+  info(obj: Record<string, unknown>, msg: string): void
+  warn(msg: string): void
+  warn(obj: Record<string, unknown>, msg: string): void
+  error(msg: string): void
+  error(obj: Record<string, unknown>, msg: string): void
+}
+
+// ─── Internal pending command tracking ──────────────────────────────────────
+
+interface PendingCommand {
+  resolve: (response: CommandResponseEvent) => void
+  reject: (err: Error) => void
+  timeout: ReturnType<typeof setTimeout>
+  /** Some commands emit a placeholder ack first ("Moving channel...") then the real result. */
+  acceptIntermediate: boolean
+  /** When acceptIntermediate=false, ignore the first ack response and wait for the next one with same command_id. */
+  ackSeen: boolean
+}
+
+const COMMAND_TIMEOUT_MS = 10_000
+
+// ─── Client ─────────────────────────────────────────────────────────────────
+
+export interface WsClientOptions {
+  url: string
+  log: PluginLogger
+  reconnectMaxBackoffMs?: number
+}
+
+export class TsBotWsClient {
+  private ws: WebSocket | null = null
+  private connected = false
+  private welcomeEvent: WelcomeEvent | null = null
+  private welcomeWaiters: Array<(welcome: WelcomeEvent) => void> = []
+  private pending = new Map<string, PendingCommand>()
+  private listeners = new Map<string, Set<EventHandler>>()
+  private wildcardListeners = new Set<EventHandler>()
+  private stopped = false
+  private reconnectAttempt = 0
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private readonly maxBackoff: number
+
+  constructor(private readonly opts: WsClientOptions) {
+    this.maxBackoff = opts.reconnectMaxBackoffMs ?? 30_000
+  }
+
+  /** Open the connection. Resolves on welcome, or rejects on first failure if `awaitWelcomeOnce` is true. */
+  async start(awaitWelcomeOnce = false, welcomeTimeoutMs = 5000): Promise<WelcomeEvent> {
+    this.stopped = false
+
+    if (awaitWelcomeOnce) {
+      // Single-shot connect, no auto-reconnect. Used for validateConfig/getBotInfo.
+      return await this.connectOnce(welcomeTimeoutMs)
+    }
+
+    // Long-lived: connect and auto-reconnect on failure.
+    this.scheduleConnect(0)
+    return await this.waitForWelcome(welcomeTimeoutMs)
+  }
+
+  /** Close the connection and stop reconnecting. */
+  stop(): void {
+    this.stopped = true
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+    if (this.ws) {
+      try { this.ws.close(1000, 'plugin shutdown') } catch { /* ignore */ }
+      this.ws = null
+    }
+    // Reject all pending commands
+    for (const [, pending] of this.pending) {
+      clearTimeout(pending.timeout)
+      pending.reject(new Error('WebSocket client stopped'))
+    }
+    this.pending.clear()
+    this.connected = false
+  }
+
+  isConnected(): boolean {
+    return this.connected
+  }
+
+  getWelcome(): WelcomeEvent | null {
+    return this.welcomeEvent
+  }
+
+  /** Subscribe to events of a specific type. Returns an unsubscribe function. */
+  on<E extends TsBotEvent>(type: EventType, handler: EventHandler<E>): () => void {
+    let set = this.listeners.get(type)
+    if (!set) {
+      set = new Set()
+      this.listeners.set(type, set)
+    }
+    set.add(handler as EventHandler)
+    return () => {
+      set!.delete(handler as EventHandler)
+    }
+  }
+
+  /** Subscribe to ALL events (useful for debugging / future routing). */
+  onAny(handler: EventHandler): () => void {
+    this.wildcardListeners.add(handler)
+    return () => { this.wildcardListeners.delete(handler) }
+  }
+
+  /** Wait until the welcome event has been received. */
+  async waitForWelcome(timeoutMs = 5000): Promise<WelcomeEvent> {
+    if (this.welcomeEvent) return this.welcomeEvent
+    return await new Promise<WelcomeEvent>((resolve, reject) => {
+      const t = setTimeout(() => {
+        const idx = this.welcomeWaiters.indexOf(resolver)
+        if (idx >= 0) this.welcomeWaiters.splice(idx, 1)
+        reject(new Error(`Timed out after ${timeoutMs}ms waiting for ts-bot welcome event`))
+      }, timeoutMs)
+      const resolver = (welcome: WelcomeEvent) => {
+        clearTimeout(t)
+        resolve(welcome)
+      }
+      this.welcomeWaiters.push(resolver)
+    })
+  }
+
+  /**
+   * Send a command and wait for the matching `command_response`.
+   *
+   * Some commands (move_channel, get_status, send_message) emit two responses:
+   * an immediate ack (placeholder) then the real result. We always wait for the
+   * "real" one (the second response with the same command_id). For simple
+   * commands (speak, stop_speaking) only one response is emitted; we accept the
+   * first immediately.
+   */
+  async sendCommand<TData = unknown>(
+    command: Record<string, unknown>,
+    opts: { expectIntermediate?: boolean; timeoutMs?: number } = {},
+  ): Promise<CommandResponseEvent & { data?: TData }> {
+    if (!this.connected || !this.ws) {
+      throw new Error('Not connected to ts-bot WebSocket')
+    }
+    const command_id = (command.command_id as string | undefined) ?? randomUUID()
+    const payload = { ...command, command_id }
+    const expectIntermediate = opts.expectIntermediate ?? false
+
+    return await new Promise((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        this.pending.delete(command_id)
+        reject(new Error(`Timed out after ${opts.timeoutMs ?? COMMAND_TIMEOUT_MS}ms waiting for ts-bot command "${String(command.type)}" response`))
+      }, opts.timeoutMs ?? COMMAND_TIMEOUT_MS)
+
+      this.pending.set(command_id, {
+        resolve: (resp) => resolve(resp as CommandResponseEvent & { data?: TData }),
+        reject,
+        timeout,
+        acceptIntermediate: !expectIntermediate,
+        ackSeen: false,
+      })
+
+      try {
+        this.ws!.send(JSON.stringify(payload))
+      } catch (err) {
+        this.pending.delete(command_id)
+        clearTimeout(timeout)
+        reject(err instanceof Error ? err : new Error(String(err)))
+      }
+    })
+  }
+
+  // ─── Internals ────────────────────────────────────────────────────────────
+
+  private scheduleConnect(delayMs: number): void {
+    if (this.stopped) return
+    if (this.reconnectTimer) clearTimeout(this.reconnectTimer)
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      this.openSocket()
+    }, delayMs)
+  }
+
+  private async connectOnce(welcomeTimeoutMs: number): Promise<WelcomeEvent> {
+    return await new Promise<WelcomeEvent>((resolve, reject) => {
+      let settled = false
+      const ws = new WebSocket(this.opts.url)
+      const t = setTimeout(() => {
+        if (settled) return
+        settled = true
+        try { ws.close() } catch { /* ignore */ }
+        reject(new Error(`Timed out after ${welcomeTimeoutMs}ms connecting to ${this.opts.url}`))
+      }, welcomeTimeoutMs)
+
+      ws.addEventListener('message', (ev) => {
+        if (settled) return
+        try {
+          const data = JSON.parse(String((ev as MessageEvent).data)) as TsBotEvent
+          if (data.type === 'welcome') {
+            settled = true
+            clearTimeout(t)
+            try { ws.close(1000, 'probe complete') } catch { /* ignore */ }
+            resolve(data as WelcomeEvent)
+          }
+        } catch { /* ignore non-JSON */ }
+      })
+
+      ws.addEventListener('error', () => {
+        if (settled) return
+        settled = true
+        clearTimeout(t)
+        reject(new Error(`WebSocket error connecting to ${this.opts.url}`))
+      })
+      ws.addEventListener('close', () => {
+        if (settled) return
+        settled = true
+        clearTimeout(t)
+        reject(new Error(`WebSocket closed before welcome from ${this.opts.url}`))
+      })
+    })
+  }
+
+  private openSocket(): void {
+    if (this.stopped) return
+    let ws: WebSocket
+    try {
+      ws = new WebSocket(this.opts.url)
+    } catch (err) {
+      this.opts.log.error({ err: String(err), url: this.opts.url }, 'Failed to construct WebSocket')
+      this.scheduleReconnect()
+      return
+    }
+    this.ws = ws
+
+    ws.addEventListener('open', () => {
+      this.opts.log.info({ url: this.opts.url }, 'ts-bot WebSocket connected')
+      this.connected = true
+      this.reconnectAttempt = 0
+    })
+
+    ws.addEventListener('message', (ev) => {
+      this.handleRawMessage(String((ev as MessageEvent).data))
+    })
+
+    ws.addEventListener('close', (ev) => {
+      this.opts.log.warn(
+        { code: (ev as CloseEvent).code, reason: (ev as CloseEvent).reason, url: this.opts.url },
+        'ts-bot WebSocket closed',
+      )
+      this.connected = false
+      this.welcomeEvent = null
+      this.ws = null
+      // Don't reject pending — let them time out, since the next reconnect may complete them is unrealistic.
+      // Actually it's safer to reject so callers don't hang.
+      for (const [, pending] of this.pending) {
+        clearTimeout(pending.timeout)
+        pending.reject(new Error('WebSocket closed before response'))
+      }
+      this.pending.clear()
+      this.scheduleReconnect()
+    })
+
+    ws.addEventListener('error', (ev) => {
+      this.opts.log.warn({ err: String((ev as ErrorEvent).message ?? ev), url: this.opts.url }, 'ts-bot WebSocket error')
+      // 'close' handler will trigger reconnect.
+    })
+  }
+
+  private scheduleReconnect(): void {
+    if (this.stopped) return
+    this.reconnectAttempt += 1
+    const base = Math.min(1000 * Math.pow(2, this.reconnectAttempt - 1), this.maxBackoff)
+    // Add jitter ±20%
+    const jitter = base * 0.2 * (Math.random() * 2 - 1)
+    const delay = Math.max(500, Math.round(base + jitter))
+    this.opts.log.info({ delayMs: delay, attempt: this.reconnectAttempt }, 'Scheduling ts-bot WebSocket reconnect')
+    this.scheduleConnect(delay)
+  }
+
+  private handleRawMessage(raw: string): void {
+    let event: TsBotEvent
+    try {
+      event = JSON.parse(raw) as TsBotEvent
+    } catch (err) {
+      this.opts.log.warn({ err: String(err), raw: raw.slice(0, 200) }, 'Received non-JSON frame from ts-bot')
+      return
+    }
+    if (!event || typeof event !== 'object' || typeof (event as { type?: unknown }).type !== 'string') {
+      return
+    }
+
+    // Welcome: capture and notify waiters
+    if (event.type === 'welcome') {
+      this.welcomeEvent = event as WelcomeEvent
+      const waiters = this.welcomeWaiters.splice(0)
+      for (const w of waiters) {
+        try { w(this.welcomeEvent) } catch { /* ignore */ }
+      }
+    }
+
+    // Command response: correlate
+    if (event.type === 'command_response') {
+      const resp = event as CommandResponseEvent
+      const id = resp.command_id
+      if (id) {
+        const pending = this.pending.get(id)
+        if (pending) {
+          // Determine if this is the placeholder ack or the final response.
+          // Heuristic: the placeholder ack has no `data` field and a `message`
+          // ending in "..." (e.g. "Moving channel...", "Sending message...").
+          // For get_status the ack has neither message nor data; the real
+          // response has `data`. For move_channel/send_message the ack ends
+          // with "...". For speak/stop_speaking only one response is sent.
+          const looksLikeAck =
+            resp.success &&
+            resp.data === undefined &&
+            typeof resp.message === 'string' &&
+            resp.message.endsWith('...')
+          const looksLikeAckEmpty =
+            resp.success &&
+            resp.data === undefined &&
+            (resp.message === undefined || resp.message === null)
+
+          // For commands that don't expect intermediate, always resolve immediately
+          // unless we explicitly know there's a follow-up (use ackSeen).
+          if (pending.acceptIntermediate) {
+            // Wait for the "final" response: skip a placeholder ack once
+            if (!pending.ackSeen && (looksLikeAck || looksLikeAckEmpty)) {
+              pending.ackSeen = true
+              // keep waiting
+            } else {
+              clearTimeout(pending.timeout)
+              this.pending.delete(id)
+              pending.resolve(resp)
+            }
+          } else {
+            clearTimeout(pending.timeout)
+            this.pending.delete(id)
+            pending.resolve(resp)
+          }
+        }
+        // else: response from another WS client (broadcast model) — ignore
+      }
+    }
+
+    // Fan out to listeners
+    const set = this.listeners.get(event.type)
+    if (set) {
+      for (const handler of set) {
+        try { handler(event) } catch (err) {
+          this.opts.log.warn({ err: String(err), type: event.type }, 'event handler threw')
+        }
+      }
+    }
+    for (const handler of this.wildcardListeners) {
+      try { handler(event) } catch (err) {
+        this.opts.log.warn({ err: String(err), type: event.type }, 'wildcard event handler threw')
+      }
+    }
+  }
+}
+
+// ─── Singleton registry ─────────────────────────────────────────────────────
+
+const clients = new Map<string, TsBotWsClient>()
+
+/** Get-or-create a singleton client per URL. Multiple consumers share it. */
+export function getOrCreateClient(opts: WsClientOptions): TsBotWsClient {
+  const existing = clients.get(opts.url)
+  if (existing) return existing
+  const client = new TsBotWsClient(opts)
+  clients.set(opts.url, client)
+  return client
+}
+
+/** Stop and forget a singleton client. */
+export function disposeClient(url: string): void {
+  const existing = clients.get(url)
+  if (existing) {
+    existing.stop()
+    clients.delete(url)
+  }
+}
+
+// ─── sender_uid helpers ─────────────────────────────────────────────────────
+
+/**
+ * The ts-bot WebSocket payload may serialize `sender_uid` either as a base64
+ * string (per spec) or as a byte array (observed in practice). Normalize to a
+ * stable base64 string for use as a contact identifier.
+ */
+export function normalizeUid(raw: number[] | string | null | undefined): string {
+  if (raw == null) return ''
+  if (typeof raw === 'string') return raw
+  if (Array.isArray(raw)) {
+    // Treat as byte array → base64
+    try {
+      const buf = Buffer.from(raw as number[])
+      return buf.toString('base64')
+    } catch {
+      return ''
+    }
+  }
+  return ''
+}

--- a/src/client/hooks/useKins.ts
+++ b/src/client/hooks/useKins.ts
@@ -171,6 +171,8 @@ export function useKins() {
                 ...(data.model !== undefined && { model: data.model as string }),
                 ...(data.providerId !== undefined && { providerId: data.providerId as string | null }),
                 ...(data.avatarUrl !== undefined && { avatarUrl: data.avatarUrl as string | null }),
+                ...(data.thinkingEnabled !== undefined && { thinkingEnabled: data.thinkingEnabled as boolean }),
+                ...(data.thinkingEffort !== undefined && { thinkingEffort: data.thinkingEffort as KinThinkingEffort | null }),
               }
             : k,
         ),
@@ -306,6 +308,10 @@ export function useKins() {
               ...(data.role !== undefined && { role: data.role }),
               ...(data.model !== undefined && { model: data.model }),
               ...(data.providerId !== undefined && { providerId: data.providerId }),
+              ...(data.thinkingConfig !== undefined && {
+                thinkingEnabled: data.thinkingConfig?.enabled === true,
+                thinkingEffort: data.thinkingConfig?.effort ?? null,
+              }),
               avatarUrl: result.kin.avatarUrl,
             }
           : k,

--- a/src/client/pages/chat/ChatPage.tsx
+++ b/src/client/pages/chat/ChatPage.tsx
@@ -297,6 +297,7 @@ export function ChatPage() {
                       providerId: selectedKin.providerId ?? null,
                       avatarUrl: selectedKin.avatarUrl,
                       thinkingEnabled: selectedKin.thinkingEnabled,
+                      thinkingEffort: selectedKin.thinkingEffort,
                     }}
                     llmModels={llmModels}
                     modelUnavailable={unavailableKinIds.has(selectedKin.id)}

--- a/src/server/services/kins.ts
+++ b/src/server/services/kins.ts
@@ -42,6 +42,7 @@ import { getHubKinId, setHubKinId } from '@/server/services/app-settings'
 import { createLogger } from '@/server/logger'
 import { deleteChannel } from '@/server/services/channels'
 import { stopJob } from '@/server/services/crons'
+import { resolveThinkingConfig } from '@/server/services/kin-engine'
 import type { KinToolConfig, KinCompactingConfig, KinThinkingConfig } from '@/shared/types'
 
 const log = createLogger('services:kins')
@@ -243,10 +244,20 @@ export async function updateKin(
   log.debug({ kinId, updatedFields: Object.keys(updates).filter((k) => k !== 'updatedAt') }, 'Kin updated')
 
   // Notify all clients
+  const resolvedThinking = resolveThinkingConfig(details.thinkingConfig)
   sseManager.broadcast({
     type: 'kin:updated',
     kinId,
-    data: { kinId, slug: details.slug, name: details.name, role: details.role, avatarUrl: details.avatarUrl, providerId: details.providerId },
+    data: {
+      kinId,
+      slug: details.slug,
+      name: details.name,
+      role: details.role,
+      avatarUrl: details.avatarUrl,
+      providerId: details.providerId,
+      thinkingEnabled: resolvedThinking.enabled === true,
+      thinkingEffort: resolvedThinking.effort ?? null,
+    },
   })
 
   return { kin: details }


### PR DESCRIPTION
First-class TeamSpeak integration for KinBot, bridging to the local
[ts-bot](https://github.com/MarlBurroW/ts-bot) WebSocket API. Already
tested live by Marlbot TS on a real TS3 server (chat + TTS both work).

## What this adds

- **A new \`teamspeak\` channel adapter** that ingests TS3 chat messages
  (and voice transcriptions when the wake-word system is enabled in
  ts-bot) into KinBot.
- **Five tools** auto-namespaced as \`plugin_teamspeak_*\`: \`get_status\`,
  \`speak\`, \`send_chat\`, \`move_channel\`, \`stop_speaking\`.

## Channel context

Every incoming message exposes a structured \`metadata\` blob (uses the
\`IncomingMessage.metadata\` field added in v0.39.0):

\`\`\`json
{
  \"modality\": \"text\" | \"voice\",
  \"chatType\": \"public_channel\" | \"private\",
  \"channel\":  { \"id\": 5, \"name\": \"Gaming\" } | null,
  \"sender\":   { \"uid\": \"<base64>\", \"name\": \"Alice\", \"session_id\": 3 },
  \"present\":  [{ \"id\": 7, \"name\": \"Bob\" }, ...] | null,
  \"bot\":      { \"channel_id\": 5, \"channel_name\": \"Gaming\" }
}
\`\`\`

KinBot serializes that into the \`<channel-context>\` block of the LLM
prompt so the Kin can adapt tone, length, voice-friendliness, etc.

## Outbound routing

| Source                                   | Behavior                                                           |
|------------------------------------------|--------------------------------------------------------------------|
| Private message                          | Chat only (no TTS)                                                 |
| Public channel, reply ≤ ttsMaxChars      | TTS only (ts-bot already echoes the spoken text to channel chat)   |
| Public channel, reply > ttsMaxChars (300)| Full text via explicit chat + short TTS notice                     |
| \`enableTtsOnPublic = false\`              | Chat only                                                           |

The discovery that **ts-bot already echoes TTS to chat automatically**
let us drop the duplicate chat copy that v0.0.1 was sending, which was
causing visible double messages during testing.

## Implementation notes

- Singleton WebSocket client per \`wsUrl\`, jittered exponential
  reconnect, \`command_id\`-correlated request/response with 10 s
  timeout.
- Two-phase response handling for \`get_status\`, \`move_channel\`,
  \`send_message\` (placeholder ack → final response).
- \`normalizeUid\` accepts ts-bot's \`sender_uid\` as either a byte array
  (current shape, observed) or a base64 string (older API draft) and
  always emits a stable base64 identifier.
- Adapter and tools share the same WS singleton so multiple consumers
  don't fight for the same connection.

## Configuration (Settings → Plugins → TeamSpeak)

| Field                  | Default                                                   |
|------------------------|-----------------------------------------------------------|
| \`wsUrl\`                | \`ws://127.0.0.1:8080/ws\`                                  |
| \`defaultVoice\`         | _(empty, ts-bot server default)_                          |
| \`ttsMaxChars\`          | \`300\`                                                     |
| \`enableTtsOnPublic\`    | \`true\`                                                    |
| \`ttsTooLongNotice\`     | \"J'ai répondu en chat, c'était trop long pour le vocal.\" |
| \`reconnectMaxBackoffMs\`| \`30000\`                                                   |

## POC scope / known limitations

- No automatic contact creation yet: the plugin runtime can't reach
  the per-Kin contact tools today. Logged as new-sender events; a
  follow-up will integrate \`find_contact_by_identifier\` once the
  plugin SDK exposes contacts.
- Every chat message is forwarded to the Kin (no mention/wake-word
  filter on the chat side) — ts-bot's wake-word handles voice.
- KinBot currently only enforces \`http:<host>\` permissions in plugin
  manifests; this plugin declares \`storage\` only. A future
  \`ws:<host>:<port>\` permission scheme would let us be more explicit.
- The bot's WS endpoint is unauthenticated and meant for localhost
  only.

## Files

- \`plugins/teamspeak/plugin.json\` — manifest + config schema.
- \`plugins/teamspeak/index.ts\` — adapter, tools, lifecycle.
- \`plugins/teamspeak/wsClient.ts\` — WS client (reconnect, correlation,
  fan-out).
- \`plugins/teamspeak/index.test.ts\` — smoke test of the export shape +
  \`normalizeUid\` round-trip.
- \`plugins/teamspeak/README.md\` — install, config, channel-context
  schema, limitations, roadmap.

## Test status

✅ Live tested on Nicolas's TS3 server (Marlbot bot, voice \`kartal\`):
- Public channel chat → TTS + single chat copy via ts-bot's auto-echo
- Private message → chat only
- Plugin loads cleanly via hot-reload
- \`<channel-context>\` arrives correctly on the LLM side

Authored-by: Marlbot TS (autonomous KinBot agent, supervised by @MarlBurroW)