### PR TITLE
feat(channels): dynamic config schema per adapter

### DIFF
--- a/PLUGIN-DEVELOPMENT.md
+++ b/PLUGIN-DEVELOPMENT.md
@@ -259,6 +259,48 @@ return {
 }
 ```
 
+#### Channel config schema
+
+Each adapter — built-in or plugin — declares the configuration fields the user
+fills in when creating a channel. The schema drives both the dynamic form
+rendered in the UI and a Zod validator that runs server-side on
+`POST /api/channels`. Stored data lives in the `channels.platformConfig` JSON
+column.
+
+Declare the schema at manifest level under `channels.<platform>.configSchema`:
+
+```json
+{
+  "channels": {
+    "my-platform": {
+      "configSchema": {
+        "fields": [
+          { "name": "apiKey", "label": "API key", "type": "password", "required": true },
+          { "name": "baseUrl", "label": "Base URL", "type": "text", "default": "https://api.example.com" },
+          { "name": "rateLimitPerMin", "label": "Rate limit (per minute)", "type": "number", "default": 60, "min": 1, "max": 600 },
+          { "name": "useTls", "label": "Use TLS", "type": "switch", "default": true }
+        ]
+      }
+    }
+  }
+}
+```
+
+Supported `type` values: `text`, `password`, `number`, `select`, `switch`.
+A field is optional unless `required: true`. `select` accepts either a list
+of strings or an array of `{ value, label }` pairs.
+
+The canonical example lives in [`plugins/teamspeak/plugin.json`](plugins/teamspeak/plugin.json).
+
+##### Secrets are auto-vaulted
+
+Any field declared with `type: "password"` is intercepted by `createChannel()`:
+the raw value is written to the secret vault and the stored `platformConfig`
+gets a `<fieldName>VaultKey` reference instead of the plain value. Adapters
+should read `<fieldName>VaultKey` from their `config` argument at runtime and
+resolve it via `getSecretValue()`. No password value ever lands in the JSON
+column or appears in logs.
+
 ### Lifecycle
 
 ```javascript

--- a/plugins/teamspeak/plugin.json
+++ b/plugins/teamspeak/plugin.json
@@ -56,5 +56,61 @@
       "max": 300000,
       "step": 1000
     }
+  },
+  "channels": {
+    "teamspeak": {
+      "configSchema": {
+        "fields": [
+          {
+            "name": "wsUrl",
+            "label": "ts-bot WebSocket URL",
+            "type": "text",
+            "default": "ws://127.0.0.1:8080/ws",
+            "required": true,
+            "placeholder": "ws://127.0.0.1:8080/ws",
+            "description": "URL of the local ts-bot WebSocket endpoint."
+          },
+          {
+            "name": "defaultVoice",
+            "label": "Default TTS voice",
+            "type": "text",
+            "placeholder": "ff_siwis",
+            "description": "Voice identifier passed to the TTS pipeline. Leave empty to use the ts-bot server default."
+          },
+          {
+            "name": "ttsMaxChars",
+            "label": "TTS soft limit (chars)",
+            "type": "number",
+            "default": 300,
+            "min": 0,
+            "max": 2000,
+            "description": "Replies longer than this are truncated to a short voice notice; full text is also sent to chat. Set to 0 to disable."
+          },
+          {
+            "name": "enableTtsOnPublic",
+            "label": "Speak replies in public channels",
+            "type": "switch",
+            "default": true,
+            "description": "When enabled, public channel replies are spoken AND copied to chat. Private messages are always chat-only."
+          },
+          {
+            "name": "ttsTooLongNotice",
+            "label": "TTS truncation notice",
+            "type": "text",
+            "default": "J'ai répondu en chat, c'était trop long pour le vocal.",
+            "description": "Short sentence spoken when a reply is too long for TTS."
+          },
+          {
+            "name": "reconnectMaxBackoffMs",
+            "label": "Max reconnect backoff (ms)",
+            "type": "number",
+            "default": 30000,
+            "min": 1000,
+            "max": 300000,
+            "description": "Upper bound for exponential reconnect backoff to the ts-bot WebSocket."
+          }
+        ]
+      }
+    }
   }
 }

--- a/src/client/components/channel/ChannelFormDialog.tsx
+++ b/src/client/components/channel/ChannelFormDialog.tsx
@@ -1,8 +1,7 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/client/components/ui/button'
 import { Input } from '@/client/components/ui/input'
-import { PasswordInput } from '@/client/components/ui/password-input'
 import { Label } from '@/client/components/ui/label'
 import {
   Dialog,
@@ -20,11 +19,12 @@ import {
 import { KinSelector } from '@/client/components/common/KinSelector'
 import type { KinOption } from '@/client/components/common/KinSelectItem'
 import { PlatformSelector } from '@/client/components/common/PlatformSelector'
+import { DynamicField } from '@/client/components/common/DynamicField'
 import { ChevronRight, HelpCircle, Lightbulb, Loader2 } from 'lucide-react'
 import { InfoTip } from '@/client/components/common/InfoTip'
 import { cn } from '@/client/lib/utils'
 import { usePlatforms } from '@/client/hooks/usePlatforms'
-import type { ChannelSummary } from '@/shared/types'
+import type { ChannelConfigSchema, ChannelSummary } from '@/shared/types'
 
 function PlatformSetupGuide({ platform }: { platform: string }) {
   const { t } = useTranslation()
@@ -79,7 +79,7 @@ interface ChannelFormDialogProps {
     kinId: string
     name: string
     platform: string
-    botToken: string
+    platformConfig: Record<string, unknown>
   }) => Promise<void>
   onUpdate?: (channelId: string, data: {
     name?: string
@@ -89,6 +89,26 @@ interface ChannelFormDialogProps {
   kins: KinOption[]
   /** Hub Kin ID — pre-selected for new channels */
   hubKinId?: string | null
+}
+
+/**
+ * Build the initial values record for an adapter's configSchema, applying
+ * declared `default` values for fields the user hasn't touched yet.
+ */
+function buildInitialFormValues(schema: ChannelConfigSchema | undefined): Record<string, unknown> {
+  if (!schema) return {}
+  const values: Record<string, unknown> = {}
+  for (const field of schema.fields) {
+    if (field.default !== undefined) values[field.name] = field.default
+  }
+  return values
+}
+
+function isRequiredFieldMissing(value: unknown, type: string): boolean {
+  if (value === undefined || value === null) return true
+  if (type === 'switch') return false // booleans are always defined once initialized
+  if (type === 'number') return typeof value === 'number' ? false : value === ''
+  return typeof value === 'string' ? value.trim() === '' : false
 }
 
 export function ChannelFormDialog({
@@ -107,29 +127,42 @@ export function ChannelFormDialog({
   const [selectedKinId, setSelectedKinId] = useState('')
   const [name, setName] = useState('')
   const [platform, setPlatform] = useState('')
-  const [botToken, setBotToken] = useState('')
+  const [formValues, setFormValues] = useState<Record<string, unknown>>({})
   const [isLoading, setIsLoading] = useState(false)
+
+  const activePlatform = useMemo(
+    () => platforms.find((p) => p.platform === platform) ?? null,
+    [platforms, platform],
+  )
+  const activeSchema = activePlatform?.configSchema
 
   // Set default platform when platforms load
   useEffect(() => {
     if (!platform && platforms.length > 0) {
       setPlatform(platforms[0]!.platform)
     }
-  }, [platforms])
+  }, [platforms]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (channel) {
       setName(channel.name)
       setPlatform(channel.platform)
       setSelectedKinId(channel.kinId)
-      setBotToken('')
+      setFormValues({})
     } else {
       setName('')
       setPlatform(platforms[0]?.platform ?? '')
       setSelectedKinId(hubKinId ?? '')
-      setBotToken('')
+      setFormValues({})
     }
-  }, [channel, open, hubKinId])
+  }, [channel, open, hubKinId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Reset form values to the active platform's schema defaults whenever
+  // the platform changes (creation flow only).
+  useEffect(() => {
+    if (isEdit) return
+    setFormValues(buildInitialFormValues(activeSchema))
+  }, [platform, activeSchema, isEdit])
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -142,12 +175,12 @@ export function ChannelFormDialog({
           kinId: selectedKinId !== channel.kinId ? selectedKinId : undefined,
         })
       } else {
-        if (!selectedKinId || !botToken.trim()) return
+        if (!selectedKinId) return
         await onSave({
           kinId: selectedKinId,
           name,
           platform,
-          botToken: botToken.trim(),
+          platformConfig: formValues,
         })
       }
       onOpenChange(false)
@@ -156,7 +189,13 @@ export function ChannelFormDialog({
     }
   }
 
-  const canSubmit = name.trim() && (isEdit || (selectedKinId && botToken.trim() && platform))
+  const requiredFieldsMissing = (activeSchema?.fields ?? [])
+    .filter((f) => f.required)
+    .some((f) => isRequiredFieldMissing(formValues[f.name], f.type))
+
+  const canSubmit = isEdit
+    ? !!name.trim()
+    : !!name.trim() && !!selectedKinId && !!platform && !requiredFieldsMissing
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -208,21 +247,19 @@ export function ChannelFormDialog({
             </div>
           )}
 
-          {/* Bot token (only for create) */}
-          {!isEdit && (
-            <div className="space-y-2">
-              <Label>{t('settings.channels.botToken')}</Label>
-              <PasswordInput
-                value={botToken}
-                onChange={(e) => setBotToken(e.target.value)}
-                placeholder={t('settings.channels.botTokenPlaceholder')}
-                required
-              />
-              <p className="text-xs text-muted-foreground">
-                {t('settings.channels.botTokenHint')}
-              </p>
-
-              {/* Platform-specific setup guide */}
+          {/* Dynamic per-adapter config fields (only for create) */}
+          {!isEdit && activeSchema && activeSchema.fields.length > 0 && (
+            <div className="space-y-4">
+              {activeSchema.fields.map((field) => (
+                <DynamicField
+                  key={field.name}
+                  field={field}
+                  value={formValues[field.name]}
+                  onChange={(v) =>
+                    setFormValues((prev) => ({ ...prev, [field.name]: v }))
+                  }
+                />
+              ))}
               <PlatformSetupGuide platform={platform} />
             </div>
           )}

--- a/src/client/components/common/DynamicField.tsx
+++ b/src/client/components/common/DynamicField.tsx
@@ -1,0 +1,150 @@
+import { Input } from '@/client/components/ui/input'
+import { PasswordInput } from '@/client/components/ui/password-input'
+import { Label } from '@/client/components/ui/label'
+import { Switch } from '@/client/components/ui/switch'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/client/components/ui/select'
+import type { ChannelConfigField } from '@/shared/types'
+
+interface DynamicFieldProps {
+  field: ChannelConfigField
+  value: unknown
+  onChange: (value: unknown) => void
+}
+
+function normalizeOptions(options: ChannelConfigField['options']): { value: string; label: string }[] {
+  if (!options) return []
+  return options.map((opt) =>
+    typeof opt === 'string' ? { value: opt, label: opt } : opt,
+  )
+}
+
+/**
+ * Renders one field from a {@link ChannelConfigField} declaration.
+ *
+ * Used by channel-creation forms to surface adapter/plugin-specific config
+ * without hardcoding each field per platform. The field types map to:
+ *   - `text`     → Input
+ *   - `password` → PasswordInput
+ *   - `number`   → Input[type=number]
+ *   - `select`   → Select (string options or value/label pairs)
+ *   - `switch`   → Switch
+ */
+export function DynamicField({ field, value, onChange }: DynamicFieldProps) {
+  const required = !!field.required
+  const labelId = `field-${field.name}`
+
+  const renderInput = () => {
+    switch (field.type) {
+      case 'password':
+        return (
+          <PasswordInput
+            id={labelId}
+            value={typeof value === 'string' ? value : ''}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={field.placeholder}
+            required={required}
+          />
+        )
+
+      case 'number':
+        return (
+          <Input
+            id={labelId}
+            type="number"
+            value={typeof value === 'number' ? value : value === undefined || value === null ? '' : String(value)}
+            min={field.min}
+            max={field.max}
+            placeholder={field.placeholder}
+            required={required}
+            onChange={(e) => {
+              const raw = e.target.value
+              if (raw === '') {
+                onChange(undefined)
+                return
+              }
+              const num = Number(raw)
+              onChange(Number.isFinite(num) ? num : raw)
+            }}
+          />
+        )
+
+      case 'switch': {
+        const checked = typeof value === 'boolean' ? value : !!field.default
+        return (
+          <Switch
+            id={labelId}
+            checked={checked}
+            onCheckedChange={(v) => onChange(v)}
+          />
+        )
+      }
+
+      case 'select': {
+        const options = normalizeOptions(field.options)
+        const current = typeof value === 'string' ? value : ''
+        return (
+          <Select value={current} onValueChange={onChange}>
+            <SelectTrigger id={labelId} className="w-full">
+              <SelectValue placeholder={field.placeholder ?? 'Select…'} />
+            </SelectTrigger>
+            <SelectContent>
+              {options.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )
+      }
+
+      case 'text':
+      default:
+        return (
+          <Input
+            id={labelId}
+            value={typeof value === 'string' ? value : ''}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={field.placeholder}
+            required={required}
+          />
+        )
+    }
+  }
+
+  if (field.type === 'switch') {
+    return (
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <Label htmlFor={labelId} className="font-normal">
+            {field.label}
+            {required && <span className="ml-1 text-destructive">*</span>}
+          </Label>
+          {field.description && (
+            <p className="text-xs text-muted-foreground">{field.description}</p>
+          )}
+        </div>
+        <div className="pt-0.5">{renderInput()}</div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={labelId}>
+        {field.label}
+        {required && <span className="ml-1 text-destructive">*</span>}
+      </Label>
+      {renderInput()}
+      {field.description && (
+        <p className="text-xs text-muted-foreground">{field.description}</p>
+      )}
+    </div>
+  )
+}

--- a/src/client/hooks/usePlatforms.ts
+++ b/src/client/hooks/usePlatforms.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { api } from '@/client/lib/api'
+import type { ChannelConfigSchema } from '@/shared/types'
 
 export interface PlatformInfo {
   platform: string
@@ -7,6 +8,7 @@ export interface PlatformInfo {
   brandColor?: string
   iconUrl?: string
   isPlugin: boolean
+  configSchema?: ChannelConfigSchema
 }
 
 /** Cached platforms — shared across all hook consumers within the same session */

--- a/src/client/pages/settings/ChannelsSettings.tsx
+++ b/src/client/pages/settings/ChannelsSettings.tsx
@@ -70,7 +70,7 @@ export function ChannelsSettings() {
     kinId: string
     name: string
     platform: string
-    botToken: string
+    platformConfig: Record<string, unknown>
   }) => {
     await api.post('/channels', data)
     await fetchChannels()

--- a/src/server/channels/adapter.ts
+++ b/src/server/channels/adapter.ts
@@ -8,6 +8,52 @@ export interface ChannelAdapterMeta {
   iconUrl?: string
 }
 
+// ─── Adapter configuration schema ───────────────────────────────────────────
+
+/**
+ * A single field declared by a {@link ChannelAdapter} so that the UI can render
+ * a dynamic configuration form and the server can validate the incoming
+ * payload before persisting it into `channels.platformConfig`.
+ *
+ * Built-ins and plugin adapters share the exact same shape. Frontend keeps
+ * UX validation; the server runs an authoritative Zod parse derived from the
+ * same declaration (see `POST /api/channels`).
+ */
+export interface ChannelConfigField {
+  /** Identifier used as the key in `platformConfig` JSON. */
+  name: string
+  /** Human-readable label shown next to the input. */
+  label: string
+  /** Widget type rendered by the dynamic form. */
+  type: 'text' | 'password' | 'number' | 'select' | 'switch'
+  /** Default value applied when the form opens / when missing on input. */
+  default?: unknown
+  /** When true, the field must be provided and non-empty. */
+  required?: boolean
+  /** Placeholder text for inputs. */
+  placeholder?: string
+  /** Help text displayed under the field. */
+  description?: string
+  /** Allowed values for `select` (either bare strings or value/label pairs). */
+  options?: string[] | { value: string; label: string }[]
+  /** Lower bound for `number`. */
+  min?: number
+  /** Upper bound for `number`. */
+  max?: number
+}
+
+/**
+ * Configuration schema declared by a {@link ChannelAdapter}. The fields drive
+ * the dynamic form in `ChannelFormDialog` and the server-side Zod validator
+ * on `POST /api/channels`.
+ *
+ * Optional today: adapters that don't declare a schema fall back to the
+ * legacy `botToken`-only behavior. Migration is opt-in per adapter.
+ */
+export interface ChannelConfigSchema {
+  fields: ChannelConfigField[]
+}
+
 // ─── Incoming attachments from an external platform ─────────────────────────
 
 export interface IncomingAttachment {
@@ -83,6 +129,15 @@ export interface ChannelAdapter {
 
   /** Optional metadata for display purposes (name, color, icon) */
   readonly meta?: ChannelAdapterMeta
+
+  /**
+   * Optional declarative configuration schema. When provided, the UI renders
+   * a dynamic form from `fields` and the server validates `platformConfig`
+   * against a Zod schema derived from it. Adapters that don't declare one
+   * keep the legacy behavior (bot-token-only form) for now — migration will
+   * happen adapter by adapter.
+   */
+  readonly configSchema?: ChannelConfigSchema
 
   /**
    * Start receiving messages. Called when a channel becomes active.

--- a/src/server/channels/adapter.ts
+++ b/src/server/channels/adapter.ts
@@ -10,49 +10,10 @@ export interface ChannelAdapterMeta {
 
 // ─── Adapter configuration schema ───────────────────────────────────────────
 
-/**
- * A single field declared by a {@link ChannelAdapter} so that the UI can render
- * a dynamic configuration form and the server can validate the incoming
- * payload before persisting it into `channels.platformConfig`.
- *
- * Built-ins and plugin adapters share the exact same shape. Frontend keeps
- * UX validation; the server runs an authoritative Zod parse derived from the
- * same declaration (see `POST /api/channels`).
- */
-export interface ChannelConfigField {
-  /** Identifier used as the key in `platformConfig` JSON. */
-  name: string
-  /** Human-readable label shown next to the input. */
-  label: string
-  /** Widget type rendered by the dynamic form. */
-  type: 'text' | 'password' | 'number' | 'select' | 'switch'
-  /** Default value applied when the form opens / when missing on input. */
-  default?: unknown
-  /** When true, the field must be provided and non-empty. */
-  required?: boolean
-  /** Placeholder text for inputs. */
-  placeholder?: string
-  /** Help text displayed under the field. */
-  description?: string
-  /** Allowed values for `select` (either bare strings or value/label pairs). */
-  options?: string[] | { value: string; label: string }[]
-  /** Lower bound for `number`. */
-  min?: number
-  /** Upper bound for `number`. */
-  max?: number
-}
-
-/**
- * Configuration schema declared by a {@link ChannelAdapter}. The fields drive
- * the dynamic form in `ChannelFormDialog` and the server-side Zod validator
- * on `POST /api/channels`.
- *
- * Optional today: adapters that don't declare a schema fall back to the
- * legacy `botToken`-only behavior. Migration is opt-in per adapter.
- */
-export interface ChannelConfigSchema {
-  fields: ChannelConfigField[]
-}
+// Declared in `src/shared/types.ts` so the client and server agree on the
+// shape used by the dynamic form and the server-side Zod validator.
+import type { ChannelConfigField, ChannelConfigSchema } from '@/shared/types'
+export type { ChannelConfigField, ChannelConfigSchema }
 
 // ─── Incoming attachments from an external platform ─────────────────────────
 

--- a/src/server/channels/configSchemaValidator.ts
+++ b/src/server/channels/configSchemaValidator.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod'
+import type { ChannelConfigField, ChannelConfigSchema } from '@/server/channels/adapter'
+
+/**
+ * Build a Zod object schema from a {@link ChannelConfigSchema} declaration.
+ *
+ * Mirrors the pattern used for MCP tool input validation
+ * (`src/server/services/mcp.ts → jsonSchemaToZod`): take a declarative schema
+ * coming from user-land (built-in adapter or plugin), and turn it into a
+ * runtime Zod schema we can `safeParse()` against `platformConfig`.
+ *
+ * Notes:
+ * - Optional fields are wrapped in `.optional()` so missing keys are OK.
+ * - `required` fields without an explicit value reject `undefined` and
+ *   empty strings (consistent with the legacy `validateConfig` behavior).
+ * - Unknown extra keys are preserved via `.passthrough()` so adapters can
+ *   keep storing implementation details (e.g. `botTokenVaultKey`,
+ *   `allowedChatIds`) alongside the declared fields.
+ */
+export function buildZodSchemaFromConfigSchema(
+  schema: ChannelConfigSchema,
+): z.ZodTypeAny {
+  const shape: Record<string, z.ZodTypeAny> = {}
+
+  for (const field of schema.fields) {
+    shape[field.name] = buildFieldSchema(field)
+  }
+
+  return z.object(shape).passthrough()
+}
+
+function buildFieldSchema(field: ChannelConfigField): z.ZodTypeAny {
+  let base: z.ZodTypeAny
+
+  switch (field.type) {
+    case 'text':
+    case 'password': {
+      let s: z.ZodString = z.string()
+      if (field.required) {
+        s = s.min(1, { message: `"${field.name}" is required` })
+      }
+      base = s
+      break
+    }
+
+    case 'number': {
+      let n: z.ZodNumber = z.number()
+      if (typeof field.min === 'number') {
+        n = n.min(field.min, { message: `"${field.name}" must be >= ${field.min}` })
+      }
+      if (typeof field.max === 'number') {
+        n = n.max(field.max, { message: `"${field.name}" must be <= ${field.max}` })
+      }
+      base = n
+      break
+    }
+
+    case 'switch':
+      base = z.boolean()
+      break
+
+    case 'select': {
+      const values = normalizeSelectValues(field.options)
+      if (values.length === 0) {
+        // No options declared — accept any string; the adapter will surface
+        // the error at runtime if needed.
+        base = z.string()
+      } else {
+        base = z.enum(values as [string, ...string[]])
+      }
+      break
+    }
+
+    default:
+      base = z.unknown()
+      break
+  }
+
+  if (!field.required) {
+    return base.optional()
+  }
+  return base
+}
+
+function normalizeSelectValues(
+  options: ChannelConfigField['options'],
+): string[] {
+  if (!Array.isArray(options)) return []
+  return options.map((opt) =>
+    typeof opt === 'string' ? opt : opt.value,
+  )
+}
+
+/**
+ * Format a Zod error into a single human-readable message, mirroring the
+ * compact error format used elsewhere in the API (e.g. `validateConfig`
+ * for plugin config in `src/server/services/plugins.ts`).
+ */
+export function formatZodIssues(error: z.ZodError): string {
+  return error.issues
+    .map((issue) => {
+      const path = issue.path.length > 0 ? issue.path.join('.') : '(root)'
+      return `${path}: ${issue.message}`
+    })
+    .join('; ')
+}

--- a/src/server/channels/discord.ts
+++ b/src/server/channels/discord.ts
@@ -1,4 +1,4 @@
-import type { ChannelAdapter, IncomingAttachment, IncomingMessageHandler, OutboundMessageParams } from '@/server/channels/adapter'
+import type { ChannelAdapter, ChannelConfigSchema, IncomingAttachment, IncomingMessageHandler, OutboundMessageParams } from '@/server/channels/adapter'
 import { readAttachmentBlob, attachmentFileName } from '@/server/channels/adapter'
 import type { ChannelAdapterMeta } from '@/server/channels/adapter'
 import { getSecretValue } from '@/server/services/vault'
@@ -337,9 +337,26 @@ function reconnect(state: GatewayState): void {
   createGateway(state)
 }
 
+// Dynamic config schema (issue #381). Field names are user-facing; the
+// runtime adapter reads `<name>VaultKey` from `platformConfig`. The vault
+// dance is performed by `createChannel()` in services/channels.ts.
+const discordConfigSchema: ChannelConfigSchema = {
+  fields: [
+    {
+      name: 'botToken',
+      label: 'Bot token',
+      type: 'password',
+      required: true,
+      placeholder: 'MTAxxxxxxxxxxxxxxxxxxxx.xxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxx',
+      description: 'Discord bot token from the Developer Portal.',
+    },
+  ],
+}
+
 export class DiscordAdapter implements ChannelAdapter {
   readonly platform = 'discord'
   readonly meta: ChannelAdapterMeta = { displayName: 'Discord', brandColor: '#5865F2' }
+  readonly configSchema = discordConfigSchema
   private gateways = new Map<string, GatewayState>()
 
   async start(channelId: string, cfg: Record<string, unknown>, onMessage: IncomingMessageHandler): Promise<void> {

--- a/src/server/channels/index.ts
+++ b/src/server/channels/index.ts
@@ -1,4 +1,4 @@
-import type { ChannelAdapter } from '@/server/channels/adapter'
+import type { ChannelAdapter, ChannelConfigSchema } from '@/server/channels/adapter'
 
 export interface ChannelPlatformInfo {
   platform: string
@@ -6,6 +6,8 @@ export interface ChannelPlatformInfo {
   brandColor?: string
   iconUrl?: string
   isPlugin: boolean
+  /** Declared configuration schema, when the adapter provides one. */
+  configSchema?: ChannelConfigSchema
 }
 
 class ChannelAdapterRegistry {
@@ -43,6 +45,7 @@ class ChannelAdapterRegistry {
       brandColor: a.meta?.brandColor,
       iconUrl: a.meta?.iconUrl,
       isPlugin: this.pluginAdapters.has(p),
+      ...(a.configSchema ? { configSchema: a.configSchema } : {}),
     }))
   }
 

--- a/src/server/channels/matrix.ts
+++ b/src/server/channels/matrix.ts
@@ -1,4 +1,4 @@
-import type { ChannelAdapter, IncomingAttachment, IncomingMessageHandler, OutboundMessageParams } from '@/server/channels/adapter'
+import type { ChannelAdapter, ChannelConfigSchema, IncomingAttachment, IncomingMessageHandler, OutboundMessageParams } from '@/server/channels/adapter'
 import { readAttachmentBlob, attachmentFileName, isImageAttachment } from '@/server/channels/adapter'
 import type { ChannelAdapterMeta } from '@/server/channels/adapter'
 import { getSecretValue } from '@/server/services/vault'
@@ -91,9 +91,33 @@ async function matrixApi(
  *
  * Matrix spec: https://spec.matrix.org/latest/client-server-api/
  */
+// Dynamic config schema (issue #381). The runtime adapter reads
+// accessTokenVaultKey and homeserverUrl from platformConfig; createChannel()
+// stores accessToken as a vault entry and copies homeserverUrl as-is.
+const matrixConfigSchema: ChannelConfigSchema = {
+  fields: [
+    {
+      name: 'homeserverUrl',
+      label: 'Homeserver URL',
+      type: 'text',
+      required: true,
+      placeholder: 'https://matrix.example.org',
+      description: 'Base URL of the Matrix homeserver (no trailing slash).',
+    },
+    {
+      name: 'accessToken',
+      label: 'Access token',
+      type: 'password',
+      required: true,
+      description: 'Bot account access token (issued via /login or admin API).',
+    },
+  ],
+}
+
 export class MatrixAdapter implements ChannelAdapter {
   readonly platform = 'matrix'
   readonly meta: ChannelAdapterMeta = { displayName: 'Matrix', brandColor: '#0DBD8B' }
+  readonly configSchema = matrixConfigSchema
 
   private syncAbortControllers = new Map<string, AbortController>()
   private handlers = new Map<string, { onMessage: IncomingMessageHandler; cfg: MatrixChannelConfig }>()

--- a/src/server/channels/signal.ts
+++ b/src/server/channels/signal.ts
@@ -1,4 +1,4 @@
-import type { ChannelAdapter, IncomingAttachment, IncomingMessageHandler, OutboundMessageParams } from '@/server/channels/adapter'
+import type { ChannelAdapter, ChannelConfigSchema, IncomingAttachment, IncomingMessageHandler, OutboundMessageParams } from '@/server/channels/adapter'
 import { readAttachmentBlob, attachmentFileName } from '@/server/channels/adapter'
 import type { ChannelAdapterMeta } from '@/server/channels/adapter'
 import { getSecretValue } from '@/server/services/vault'
@@ -89,9 +89,34 @@ async function signalApi(
  * Incoming messages are received via webhook callbacks from signal-cli.
  * The webhook URL is registered when the channel starts.
  */
+// Dynamic config schema (issue #381). `apiUrl` is treated as a password
+// to avoid leaking internal topology in logs/UI listings. phoneNumber is
+// stored plain. The vault dance is performed by `createChannel()`.
+const signalConfigSchema: ChannelConfigSchema = {
+  fields: [
+    {
+      name: 'apiUrl',
+      label: 'signal-cli REST API URL',
+      type: 'password',
+      required: true,
+      placeholder: 'http://signal-cli:8080',
+      description: 'Base URL of the signal-cli REST API instance.',
+    },
+    {
+      name: 'phoneNumber',
+      label: 'Phone number',
+      type: 'text',
+      required: true,
+      placeholder: '+33612345678',
+      description: 'E.164 number registered with signal-cli.',
+    },
+  ],
+}
+
 export class SignalAdapter implements ChannelAdapter {
   readonly platform = 'signal'
   readonly meta: ChannelAdapterMeta = { displayName: 'Signal', brandColor: '#3A76F0' }
+  readonly configSchema = signalConfigSchema
 
   /** Store message handlers for webhook processing */
   private handlers = new Map<string, { onMessage: IncomingMessageHandler; cfg: SignalChannelConfig }>()

--- a/src/server/channels/slack.ts
+++ b/src/server/channels/slack.ts
@@ -1,4 +1,4 @@
-import type { ChannelAdapter, IncomingAttachment, IncomingMessageHandler, OutboundMessageParams } from '@/server/channels/adapter'
+import type { ChannelAdapter, ChannelConfigSchema, IncomingAttachment, IncomingMessageHandler, OutboundMessageParams } from '@/server/channels/adapter'
 import { readAttachmentBlob, attachmentFileName } from '@/server/channels/adapter'
 import type { ChannelAdapterMeta } from '@/server/channels/adapter'
 import { getSecretValue } from '@/server/services/vault'
@@ -217,9 +217,33 @@ export async function handleSlackWebhook(
   return { status: 200, body: { ok: true } }
 }
 
+// Dynamic config schema (issue #381). Field names are user-facing; the
+// runtime adapter reads `<name>VaultKey` from `platformConfig`. The vault
+// dance is performed by `createChannel()` in services/channels.ts.
+const slackConfigSchema: ChannelConfigSchema = {
+  fields: [
+    {
+      name: 'botToken',
+      label: 'Bot token',
+      type: 'password',
+      required: true,
+      placeholder: 'xoxb-…',
+      description: 'Slack bot OAuth token (xoxb-…) from the app config.',
+    },
+    {
+      name: 'signingSecret',
+      label: 'Signing secret',
+      type: 'password',
+      required: true,
+      description: 'Slack signing secret used to verify request authenticity.',
+    },
+  ],
+}
+
 export class SlackAdapter implements ChannelAdapter {
   readonly platform = 'slack'
   readonly meta: ChannelAdapterMeta = { displayName: 'Slack', brandColor: '#4A154B' }
+  readonly configSchema = slackConfigSchema
 
   async start(channelId: string, cfg: Record<string, unknown>, onMessage: IncomingMessageHandler): Promise<void> {
     const token = await resolveToken(cfg)

--- a/src/server/channels/telegram.ts
+++ b/src/server/channels/telegram.ts
@@ -1,4 +1,4 @@
-import type { ChannelAdapter, IncomingMessageHandler, OutboundMessageParams, OutboundAttachment } from '@/server/channels/adapter'
+import type { ChannelAdapter, ChannelConfigSchema, IncomingMessageHandler, OutboundMessageParams, OutboundAttachment } from '@/server/channels/adapter'
 import { readAttachmentBlob, attachmentFileName, isImageAttachment } from '@/server/channels/adapter'
 import type { ChannelAdapterMeta } from '@/server/channels/adapter'
 import { getSecretValue } from '@/server/services/vault'
@@ -80,9 +80,28 @@ interface TelegramPollingState {
   allowedChatIds: Set<string> | null
 }
 
+// Dynamic config schema (issue #381).
+// Schema field names are USER-FACING form input names. At runtime this adapter
+// reads `<name>VaultKey` from `platformConfig` (e.g. `botTokenVaultKey`),
+// populated by `createChannel()` in services/channels.ts which performs the
+// vault dance based on this schema. The drift is an internal storage detail.
+const telegramConfigSchema: ChannelConfigSchema = {
+  fields: [
+    {
+      name: 'botToken',
+      label: 'Bot token',
+      type: 'password',
+      required: true,
+      placeholder: '123456789:ABC-DEF1234ghIkl-zyx57W2v1u123ew11',
+      description: 'Telegram bot token obtained from @BotFather.',
+    },
+  ],
+}
+
 export class TelegramAdapter implements ChannelAdapter {
   readonly platform = 'telegram'
   readonly meta: ChannelAdapterMeta = { displayName: 'Telegram', brandColor: '#26A5E4' }
+  readonly configSchema = telegramConfigSchema
   private pollers = new Map<string, TelegramPollingState>()
 
   async start(channelId: string, cfg: Record<string, unknown>, onMessage?: IncomingMessageHandler): Promise<void> {

--- a/src/server/channels/whatsapp.ts
+++ b/src/server/channels/whatsapp.ts
@@ -1,4 +1,4 @@
-import type { ChannelAdapter, IncomingAttachment, IncomingMessageHandler, OutboundMessageParams, OutboundAttachment } from '@/server/channels/adapter'
+import type { ChannelAdapter, ChannelConfigSchema, IncomingAttachment, IncomingMessageHandler, OutboundMessageParams, OutboundAttachment } from '@/server/channels/adapter'
 import { readAttachmentBlob, attachmentFileName } from '@/server/channels/adapter'
 import type { ChannelAdapterMeta } from '@/server/channels/adapter'
 import { getSecretValue } from '@/server/services/vault'
@@ -70,9 +70,41 @@ async function whatsappApi(
   return data
 }
 
+// Dynamic config schema (issue #381). Password fields are vaulted by
+// `createChannel()` (stored as `<name>VaultKey` in `platformConfig`).
+// Non-password fields are stored as-is. The adapter reads accessTokenVaultKey,
+// verifyTokenVaultKey, and phoneNumberId from platformConfig at runtime.
+const whatsappConfigSchema: ChannelConfigSchema = {
+  fields: [
+    {
+      name: 'accessToken',
+      label: 'Access token',
+      type: 'password',
+      required: true,
+      description: 'Meta WhatsApp Cloud API permanent access token.',
+    },
+    {
+      name: 'phoneNumberId',
+      label: 'Phone number ID',
+      type: 'text',
+      required: true,
+      placeholder: '123456789012345',
+      description: 'Meta phone number identifier (numeric, not the phone number itself).',
+    },
+    {
+      name: 'verifyToken',
+      label: 'Webhook verify token',
+      type: 'password',
+      required: true,
+      description: 'Token Meta sends back on webhook subscription challenges.',
+    },
+  ],
+}
+
 export class WhatsAppAdapter implements ChannelAdapter {
   readonly platform = 'whatsapp'
   readonly meta: ChannelAdapterMeta = { displayName: 'WhatsApp', brandColor: '#25D366' }
+  readonly configSchema = whatsappConfigSchema
 
   async start(channelId: string, cfg: Record<string, unknown>): Promise<void> {
     // WhatsApp Cloud API uses a webhook configured in Meta Developer Console.

--- a/src/server/routes/channels.ts
+++ b/src/server/routes/channels.ts
@@ -18,6 +18,10 @@ import {
 } from '@/server/services/channels'
 import type { AppVariables } from '@/server/app'
 import { channelAdapters } from '@/server/channels/index'
+import {
+  buildZodSchemaFromConfigSchema,
+  formatZodIssues,
+} from '@/server/channels/configSchemaValidator'
 import { createLogger } from '@/server/logger'
 
 const log = createLogger('routes:channels')
@@ -96,6 +100,13 @@ channelRoutes.post('/', async (c) => {
     botToken: string
     allowedChatIds?: string[]
     autoCreateContacts?: boolean
+    /**
+     * Forward-compatible field for the dynamic channel config schema.
+     * Only validated when the resolved adapter declares a `configSchema`.
+     * In this transitional commit, none of the built-ins or the teamspeak
+     * plugin declare one, so this field is ignored end-to-end.
+     */
+    platformConfig?: Record<string, unknown>
   }>()
 
   if (!body.kinId || !body.name || !body.platform || !body.botToken) {
@@ -105,12 +116,32 @@ channelRoutes.post('/', async (c) => {
     )
   }
 
-  if (!channelAdapters.get(body.platform)) {
+  const adapter = channelAdapters.get(body.platform)
+  if (!adapter) {
     const available = channelAdapters.list().join(', ')
     return c.json(
       { error: { code: 'VALIDATION_ERROR', message: `Invalid platform. Registered: ${available}` } },
       400,
     )
+  }
+
+  // Dynamic configSchema validation (opt-in per adapter).
+  // Adapters that don't declare a `configSchema` keep the legacy behavior
+  // (the 6 built-ins + the teamspeak plugin on day 1).
+  if (adapter.configSchema) {
+    const zodSchema = buildZodSchemaFromConfigSchema(adapter.configSchema)
+    const parsed = zodSchema.safeParse(body.platformConfig ?? {})
+    if (!parsed.success) {
+      return c.json(
+        {
+          error: {
+            code: 'VALIDATION_ERROR',
+            message: `Invalid platformConfig: ${formatZodIssues(parsed.error)}`,
+          },
+        },
+        400,
+      )
+    }
   }
 
   // Verify Kin exists

--- a/src/server/routes/channels.ts
+++ b/src/server/routes/channels.ts
@@ -97,21 +97,14 @@ channelRoutes.post('/', async (c) => {
     kinId: string
     name: string
     platform: string
-    botToken: string
+    platformConfig?: Record<string, unknown>
     allowedChatIds?: string[]
     autoCreateContacts?: boolean
-    /**
-     * Forward-compatible field for the dynamic channel config schema.
-     * Only validated when the resolved adapter declares a `configSchema`.
-     * In this transitional commit, none of the built-ins or the teamspeak
-     * plugin declare one, so this field is ignored end-to-end.
-     */
-    platformConfig?: Record<string, unknown>
   }>()
 
-  if (!body.kinId || !body.name || !body.platform || !body.botToken) {
+  if (!body.kinId || !body.name || !body.platform) {
     return c.json(
-      { error: { code: 'VALIDATION_ERROR', message: 'kinId, name, platform, and botToken are required' } },
+      { error: { code: 'VALIDATION_ERROR', message: 'kinId, name, and platform are required' } },
       400,
     )
   }
@@ -125,16 +118,10 @@ channelRoutes.post('/', async (c) => {
     )
   }
 
-  // LEGACY: remap top-level `botToken` → `platformConfig.botToken` so the
-  // current single-field UI passes Zod validation against adapter schemas.
-  // Removed once the dynamic frontend lands (see issue #381 commit 5).
-  const platformConfig: Record<string, unknown> = { ...(body.platformConfig ?? {}) }
-  if (body.botToken && platformConfig.botToken === undefined) {
-    platformConfig.botToken = body.botToken
-  }
-
-  // Dynamic configSchema validation (opt-in per adapter).
-  // Adapters that don't declare a `configSchema` keep the legacy behavior.
+  // Validate platformConfig against the adapter's declarative schema. Adapters
+  // without a configSchema accept any platformConfig (none of the built-ins
+  // are in that state post-#381 but plugins may temporarily ship without one).
+  const platformConfig: Record<string, unknown> = body.platformConfig ?? {}
   if (adapter.configSchema) {
     const zodSchema = buildZodSchemaFromConfigSchema(adapter.configSchema)
     const parsed = zodSchema.safeParse(platformConfig)
@@ -162,7 +149,7 @@ channelRoutes.post('/', async (c) => {
       kinId: body.kinId,
       name: body.name,
       platform: body.platform,
-      botToken: body.botToken,
+      platformConfig,
       allowedChatIds: body.allowedChatIds,
       autoCreateContacts: body.autoCreateContacts,
       createdBy: 'user',

--- a/src/server/routes/channels.ts
+++ b/src/server/routes/channels.ts
@@ -125,12 +125,19 @@ channelRoutes.post('/', async (c) => {
     )
   }
 
+  // LEGACY: remap top-level `botToken` → `platformConfig.botToken` so the
+  // current single-field UI passes Zod validation against adapter schemas.
+  // Removed once the dynamic frontend lands (see issue #381 commit 5).
+  const platformConfig: Record<string, unknown> = { ...(body.platformConfig ?? {}) }
+  if (body.botToken && platformConfig.botToken === undefined) {
+    platformConfig.botToken = body.botToken
+  }
+
   // Dynamic configSchema validation (opt-in per adapter).
-  // Adapters that don't declare a `configSchema` keep the legacy behavior
-  // (the 6 built-ins + the teamspeak plugin on day 1).
+  // Adapters that don't declare a `configSchema` keep the legacy behavior.
   if (adapter.configSchema) {
     const zodSchema = buildZodSchemaFromConfigSchema(adapter.configSchema)
-    const parsed = zodSchema.safeParse(body.platformConfig ?? {})
+    const parsed = zodSchema.safeParse(platformConfig)
     if (!parsed.success) {
       return c.json(
         {

--- a/src/server/services/channels.ts
+++ b/src/server/services/channels.ts
@@ -74,7 +74,13 @@ interface CreateChannelParams {
   kinId: string
   name: string
   platform: ChannelPlatform
-  botToken: string
+  /**
+   * Raw configuration values keyed by the field names declared in the
+   * adapter's configSchema (e.g. `{ botToken: 'xxx', allowedChatIds: [...] }`).
+   * Password fields are auto-vaulted before persistence and replaced with
+   * `<name>VaultKey` references in the stored `platformConfig` JSON.
+   */
+  platformConfig?: Record<string, unknown>
   allowedChatIds?: string[]
   autoCreateContacts?: boolean
   createdBy?: 'user' | 'kin'
@@ -92,19 +98,41 @@ export async function createChannel(params: CreateChannelParams) {
     throw new Error(`Max channels per Kin (${config.channels.maxPerKin}) reached`)
   }
 
+  const adapter = channelAdapters.get(params.platform)
+
   const id = uuid()
   const now = new Date()
+  const input = params.platformConfig ?? {}
 
-  // Store bot token in vault
-  const vaultKey = `channel_${params.platform}_${id}`
-  await createSecret(vaultKey, params.botToken, undefined, `Bot token for ${params.platform} channel "${params.name}"`)
-
-  // Build platform config
-  const platformConfig: Record<string, unknown> = {
-    botTokenVaultKey: vaultKey,
+  // Build stored platformConfig from the adapter's schema. Password fields
+  // are vaulted and replaced with `<name>VaultKey`; other declared fields
+  // are stored as-is. Undeclared keys in `input` are dropped silently
+  // (the route already Zod-validates against the schema before calling).
+  // Naming convention for new vault keys: `channel_<platform>_<id>_<field>`.
+  // Pre-existing channels created before issue #381 used the older single-key
+  // format `channel_<platform>_<id>` (for botToken only); those entries
+  // remain valid because their `botTokenVaultKey` value in DB still points
+  // to that exact secret — the adapter just reads whatever VaultKey is in
+  // the stored config.
+  const stored: Record<string, unknown> = {}
+  for (const field of adapter?.configSchema?.fields ?? []) {
+    const value = input[field.name]
+    if (value === undefined || value === null || value === '') continue
+    if (field.type === 'password') {
+      const vaultKey = `channel_${params.platform}_${id}_${field.name}`
+      await createSecret(
+        vaultKey,
+        String(value),
+        undefined,
+        `${field.label} for ${params.platform} channel "${params.name}"`,
+      )
+      stored[`${field.name}VaultKey`] = vaultKey
+    } else {
+      stored[field.name] = value
+    }
   }
   if (params.allowedChatIds?.length) {
-    platformConfig.allowedChatIds = params.allowedChatIds
+    stored.allowedChatIds = params.allowedChatIds
   }
 
   await db.insert(channels).values({
@@ -112,7 +140,7 @@ export async function createChannel(params: CreateChannelParams) {
     kinId: params.kinId,
     name: params.name,
     platform: params.platform,
-    platformConfig: JSON.stringify(platformConfig),
+    platformConfig: JSON.stringify(stored),
     status: 'inactive',
     autoCreateContacts: params.autoCreateContacts ?? true,
     messagesReceived: 0,
@@ -206,11 +234,20 @@ export async function deleteChannel(channelId: string) {
     }
   }
 
-  // Delete vault secret
-  const cfg = JSON.parse(existing.platformConfig) as { botTokenVaultKey?: string }
-  if (cfg.botTokenVaultKey) {
-    const secret = await getSecretByKey(cfg.botTokenVaultKey)
-    if (secret) await deleteSecret(secret.id)
+  // Delete every vault secret referenced by the stored platformConfig.
+  // Any key ending in `VaultKey` is treated as a vault reference (the
+  // generalized vault dance writes `<name>VaultKey` for each password
+  // field in the adapter's configSchema). Pre-#381 channels stored only
+  // `botTokenVaultKey`; this still cleans them up.
+  const storedConfig = JSON.parse(existing.platformConfig) as Record<string, unknown>
+  for (const [key, value] of Object.entries(storedConfig)) {
+    if (typeof value !== 'string' || !key.endsWith('VaultKey')) continue
+    try {
+      const secret = await getSecretByKey(value)
+      if (secret) await deleteSecret(secret.id)
+    } catch (err) {
+      log.warn({ channelId, key, err }, 'Failed to delete vault secret during channel delete')
+    }
   }
 
   await db.delete(channels).where(eq(channels.id, channelId))

--- a/src/server/services/plugins.ts
+++ b/src/server/services/plugins.ts
@@ -794,10 +794,19 @@ class PluginManager {
         }
       }
 
-      // Register channels
+      // Register channels. If the manifest declares
+      // `channels.<platform>.configSchema` for this adapter and the adapter
+      // doesn't already expose one, attach the manifest schema so that
+      // `channelAdapters.listWithMeta()` and the route-level Zod validator
+      // pick it up. Manifest-level declarations are encouraged for plugins
+      // because they remain discoverable without executing plugin code.
       if (exports.channels) {
         for (const [channelName, adapter] of Object.entries(exports.channels)) {
           try {
+            const manifestEntry = plugin.manifest.channels?.[adapter.platform]
+            if (manifestEntry?.configSchema && !adapter.configSchema) {
+              ;(adapter as { configSchema?: typeof manifestEntry.configSchema }).configSchema = manifestEntry.configSchema
+            }
             channelAdapters.registerPlugin(adapter)
             plugin.registeredChannels.push({
               platform: adapter.platform,

--- a/src/server/services/plugins.ts
+++ b/src/server/services/plugins.ts
@@ -224,6 +224,33 @@ export function validateManifest(data: unknown): { valid: boolean; errors: strin
     }
   }
 
+  // Validate optional channels metadata (permissive: shape only, no value
+  // checks). See PluginManifest.channels in src/shared/types/plugin.ts.
+  if (m.channels !== undefined) {
+    if (typeof m.channels !== 'object' || m.channels === null || Array.isArray(m.channels)) {
+      errors.push('channels must be an object keyed by platform name')
+    } else {
+      const chans = m.channels as Record<string, unknown>
+      for (const [platform, entry] of Object.entries(chans)) {
+        if (entry === null || typeof entry !== 'object' || Array.isArray(entry)) {
+          errors.push(`channels.${platform} must be an object`)
+          continue
+        }
+        const e = entry as Record<string, unknown>
+        if (e.configSchema !== undefined) {
+          if (typeof e.configSchema !== 'object' || e.configSchema === null || Array.isArray(e.configSchema)) {
+            errors.push(`channels.${platform}.configSchema must be an object`)
+            continue
+          }
+          const cs = e.configSchema as Record<string, unknown>
+          if (!Array.isArray(cs.fields)) {
+            errors.push(`channels.${platform}.configSchema.fields must be an array`)
+          }
+        }
+      }
+    }
+  }
+
   return { valid: errors.length === 0, errors }
 }
 

--- a/src/server/tools/channel-tools.ts
+++ b/src/server/tools/channel-tools.ts
@@ -156,11 +156,16 @@ export const createChannelTool: ToolRegistration = {
         }
 
         try {
+          // The Kin-facing tool exposes a single `bot_token` for ergonomics;
+          // map it to the unified `platformConfig.botToken` field the service
+          // expects. Multi-secret adapters (Slack signing-secret, WhatsApp
+          // verify-token, …) aren't reachable from this tool — Kins still
+          // have to use the UI / API for those.
           const channel = await createChannel({
             kinId: ctx.kinId,
             name,
             platform: platform as ChannelPlatform,
-            botToken: bot_token,
+            platformConfig: { botToken: bot_token },
             allowedChatIds: allowed_chat_ids,
             autoCreateContacts: auto_create_contacts,
             createdBy: 'kin',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -325,6 +325,31 @@ export type ChannelStatus = 'active' | 'inactive' | 'error'
 
 export type ChannelUserMappingStatus = 'pending'
 
+/**
+ * A single field declared by a channel adapter so the UI can render a dynamic
+ * configuration form and the server can validate the payload before storing it
+ * in `channels.platformConfig`.
+ *
+ * Mirrored to plugin manifests via `PluginChannelConfigField` in
+ * `src/shared/types/plugin.ts`.
+ */
+export interface ChannelConfigField {
+  name: string
+  label: string
+  type: 'text' | 'password' | 'number' | 'select' | 'switch'
+  default?: unknown
+  required?: boolean
+  placeholder?: string
+  description?: string
+  options?: string[] | { value: string; label: string }[]
+  min?: number
+  max?: number
+}
+
+export interface ChannelConfigSchema {
+  fields: ChannelConfigField[]
+}
+
 /** Channel summary as returned by GET /api/channels */
 export interface ChannelSummary {
   id: string

--- a/src/shared/types/plugin.ts
+++ b/src/shared/types/plugin.ts
@@ -17,6 +17,38 @@ export interface PluginConfigField {
   rows?: number            // text
 }
 
+/**
+ * Field declaration for a channel adapter's configuration schema, as
+ * surfaced in the plugin manifest (`channels.<platform>.configSchema.fields`).
+ *
+ * Mirrors `ChannelConfigField` from `src/server/channels/adapter.ts`. Kept
+ * permissive here on purpose: the manifest is parsed before the channel
+ * adapter is instantiated, so we tolerate unknown fields and rely on the
+ * adapter contract for stricter checks downstream.
+ */
+export interface PluginChannelConfigField {
+  name: string
+  label: string
+  type: 'text' | 'password' | 'number' | 'select' | 'switch'
+  default?: unknown
+  required?: boolean
+  placeholder?: string
+  description?: string
+  options?: string[] | { value: string; label: string }[]
+  min?: number
+  max?: number
+}
+
+export interface PluginChannelConfigSchema {
+  fields: PluginChannelConfigField[]
+}
+
+export interface PluginChannelManifestEntry {
+  configSchema?: PluginChannelConfigSchema
+  /** Forward-compatible: plugin manifests may grow other per-channel keys. */
+  [key: string]: unknown
+}
+
 export interface PluginManifest {
   name: string
   version: string
@@ -30,6 +62,13 @@ export interface PluginManifest {
   permissions?: string[]
   dependencies?: Record<string, string>  // plugin-name → semver range (e.g. ">=1.0.0")
   config?: Record<string, PluginConfigField>
+  /**
+   * Optional declarative metadata for the channel adapters this plugin
+   * exposes. Currently used to declare a `configSchema` that the UI / server
+   * pick up via the standard `ChannelAdapter.configSchema` getter. Accepted
+   * permissively at manifest level — see `validateManifest` for details.
+   */
+  channels?: Record<string, PluginChannelManifestEntry>
 }
 
 export interface PluginProviderMeta {


### PR DESCRIPTION
## Summary

Refs #381. Replaces the hardcoded **Bot Token** field on channel creation with a per-adapter dynamic config schema. Each adapter (built-in or plugin) declares its own fields via `configSchema`; the server Zod-validates the payload on `POST /api/channels` and `createChannel()` auto-vaults password fields. The UI renders the form dynamically from the schema returned by `GET /api/channels/platforms`.

## Commits

1. **`feat(channels): add ChannelConfigSchema types and Zod validation`** — rebases the existing schema infrastructure onto current main: `ChannelConfigField`/`ChannelConfigSchema` types, `buildZodSchemaFromConfigSchema()` validator with `.passthrough()`, registry exposure via `listWithMeta()`, permissive plugin manifest acceptance.
2. **`feat(channels): declare configSchema on Telegram/Discord/Slack + legacy remap`** — schemas with user-facing field names. Adds a transitional route-level legacy remap (`body.botToken` → `platformConfig.botToken`) so the old single-field UI keeps creating Telegram and Discord channels during the in-PR transition. Slack now requires `signingSecret` and 400s on the legacy form (pre-existing gap, see below).
3. **`feat(channels): declare configSchema on WhatsApp/Signal/Matrix`** — multi-secret adapters get their schemas. These had never been creatable through the legacy form anyway because their `start()` always needed multiple vault keys.
4. **`feat(plugins): wire manifest channels.<platform>.configSchema and add teamspeak schema`** — completes the manifest-level plumbing started in commit 1: the loader now attaches `manifest.channels.<platform>.configSchema` to the registered adapter so it surfaces via `listWithMeta()` and the route validator. Adds the canonical schema to the teamspeak plugin manifest (`wsUrl`, `defaultVoice`, `ttsMaxChars`, `enableTtsOnPublic`, `ttsTooLongNotice`, `reconnectMaxBackoffMs`).
5. **`feat(channels): dynamic config form + generalize vault dance + remove legacy remap`** — closes the end-to-end path:
   - `createChannel()` is generalized: consults `adapter.configSchema.fields`, vaults every `password` field as `<name>VaultKey`, copies the rest as-is. `deleteChannel()` now cleans every `*VaultKey` (was hardcoded to `botTokenVaultKey`).
   - `POST /api/channels` drops the transitional legacy remap; body is now `{ kinId, name, platform, platformConfig, allowedChatIds?, autoCreateContacts? }`.
   - New `src/client/components/common/DynamicField.tsx` renders text/password/number/select/switch inputs against `ChannelConfigField`, using design-system tokens only.
   - `ChannelFormDialog` drops the hardcoded Bot Token block and loops `activePlatform.configSchema.fields` through `DynamicField`. Schema defaults pre-populate the form on platform change.
   - `usePlatforms` exposes `configSchema` on `PlatformInfo`.
   - `PLUGIN-DEVELOPMENT.md` gains a **Channel config schema** section with the teamspeak example and the auto-vault contract.

## Migration safety

Existing channels keep working unchanged. **No DB migration.**

The schema-to-storage drift (user-facing names like `botToken` vs runtime storage names like `botTokenVaultKey`) is an internal storage detail of `createChannel()`. Adapter runtime code is unaffected: each adapter still reads `<name>VaultKey` from its config exactly as before. Pre-#381 channels stored a vault key under the older `channel_<platform>_<channelId>` format; that value is still pointed to by `botTokenVaultKey` in the row, and `getSecretByKey()` resolves it fine.

## Transitional regression (resolves inside this PR)

Between commits 2/3 and commit 5, creating new Slack/WhatsApp/Signal/Matrix channels via the legacy single-field form would 400 (Zod required-field validation). These channels never worked through the legacy form anyway — the adapters' `start()` always needed multiple vault keys the legacy UI never collected. Commit 5 ships the dynamic form that handles them properly. **No customer-facing regression window since the PR lands as one merge.**

## Manual tests

- [x] `tsc --noEmit --skipLibCheck` → 0 errors on every commit
- [x] `bun test` → 3444 pass / 0 fail on every commit
- [x] `bun run build` → succeeds, no warnings beyond pre-existing chunk-size hints
- [ ] **Manual UI test (please verify before merge):**
  - Create a Telegram channel via the new form (renders a single `botToken` password field) → channel created, vault entry present, activates fine
  - Create a teamspeak channel via the new form (renders `wsUrl` + 5 others) → channel created
  - Existing pre-PR Telegram channel still activates after restart
  - Form renders correctly across palettes (aurora, sunset, dark mode)

## Out of scope (volontaire)

- Bug `recipient int vs string` on teamspeak plugin → separate PR
- Twilio SMS plugin → after this PR merges
- Editing per-field channel config post-creation (this PR only covers the create form; `updateChannel` still limited to `name`, `kinId`, `allowedChatIds`, `autoCreateContacts`)
- i18n keys for field labels (static English for v1)

Do **not** auto-close #381 — owner will close after merge.