### PR TITLE
feat(tools): generalize create_channel to accept arbitrary platform config

### DIFF
--- a/src/server/tools/channel-tools.ts
+++ b/src/server/tools/channel-tools.ts
@@ -140,32 +140,29 @@ export const createChannelTool: ToolRegistration = {
   create: (ctx) =>
     tool({
       description:
-        'Create a new messaging channel. Retrieve bot tokens from Vault (get_secret) — never hardcode them.',
+        'Create a new messaging channel. The `config` keys must match the platform\'s declared configuration fields (e.g. Telegram needs `botToken`; Slack needs `botToken` + `signingSecret`; WhatsApp needs `accessToken` + `phoneNumberId` + `verifyToken`; Matrix needs `homeserverUrl` + `accessToken`). Password-type fields are auto-vaulted by the server — fetch secret values from Vault via get_secret() rather than hardcoding them. If you don\'t know the expected fields for a platform, attempt the call: the validation error lists what\'s missing.',
       inputSchema: z.object({
         name: z.string(),
-        platform: z.string().describe('e.g. "telegram", "discord"'),
-        bot_token: z.string(),
+        platform: z.string().describe('e.g. "telegram", "discord", "slack", "whatsapp", "signal", "matrix", or a plugin platform'),
+        config: z
+          .record(z.string(), z.union([z.string(), z.number(), z.boolean()]))
+          .describe('Configuration values keyed by adapter field name (e.g. { botToken: "..." } for Telegram, { botToken: "...", signingSecret: "..." } for Slack).'),
         allowed_chat_ids: z.array(z.string()).optional().describe('Restrict to specific chat/group IDs'),
         auto_create_contacts: z.boolean().optional().describe('Default: true'),
       }),
-      execute: async ({ name, platform, bot_token, allowed_chat_ids, auto_create_contacts }) => {
-        log.debug({ kinId: ctx.kinId, platform, name }, 'Channel creation requested')
+      execute: async ({ name, platform, config, allowed_chat_ids, auto_create_contacts }) => {
+        log.debug({ kinId: ctx.kinId, platform, name, configKeys: Object.keys(config) }, 'Channel creation requested')
 
         if (!channelAdapters.get(platform)) {
           return { error: `Unknown platform "${platform}". Available: ${channelAdapters.list().join(', ')}` }
         }
 
         try {
-          // The Kin-facing tool exposes a single `bot_token` for ergonomics;
-          // map it to the unified `platformConfig.botToken` field the service
-          // expects. Multi-secret adapters (Slack signing-secret, WhatsApp
-          // verify-token, …) aren't reachable from this tool — Kins still
-          // have to use the UI / API for those.
           const channel = await createChannel({
             kinId: ctx.kinId,
             name,
             platform: platform as ChannelPlatform,
-            platformConfig: { botToken: bot_token },
+            platformConfig: config,
             allowedChatIds: allowed_chat_ids,
             autoCreateContacts: auto_create_contacts,
             createdBy: 'kin',


### PR DESCRIPTION
## Summary

Follow-up to #385 (issue #381). Replaces the Kin-facing `create_channel` tool's flat `bot_token` argument with a generic `config: Record<string, string | number | boolean>` so multi-secret adapters become reachable through tools.

## Context

After #385 landed, the Kin-facing `create_channel` tool was the only remaining single-secret hotspot:

- **Telegram / Discord** — worked (single `botToken` field, mapped from `bot_token`).
- **Slack / WhatsApp / Signal / Matrix** — 400 Zod, because the legacy tool sent `{ botToken: bot_token }` but the adapter schemas require additional fields (`signingSecret`, `phoneNumberId`, `verifyToken`, `homeserverUrl`, …).

The fix is small because the service-level vault dance is already general: `createChannel()` consults `adapter.configSchema.fields` and auto-vaults every `password` field. The tool just needs to forward whatever the model passes.

## What changed

- `inputSchema.bot_token: z.string()` → `inputSchema.config: z.record(z.string(), z.union([z.string(), z.number(), z.boolean()]))`.
- Tool description now spells out the field names per built-in platform and notes that the Zod validation error message is self-documenting on failure.
- Execute body passes `platformConfig: config` directly (no remapping).

No service or schema changes. No DB migration. No frontend impact.

## Tests

- `tsc --noEmit --skipLibCheck` → 0
- `bun test` → 3444 pass / 0 fail
- No existing test exercised `createChannelTool` (verified via grep). The change is mechanical: arg renamed, payload threaded through unchanged.

## Note on Kin discoverability

Kins discover the per-platform field set the same way they handle any unfamiliar tool today: attempt the call with their best guess, read the Zod validation error message, retry. This matches `update_kin_settings`, `set_voice`, and other generic tools already in the codebase. A future improvement would be a `list_channel_platforms` tool returning each platform's `configSchema.fields`, but it's not needed for this PR.

## Out of scope

- Rotating secrets via `update_channel` (the tool still doesn't expose `platformConfig`)
- Listing platform schemas through a tool
- Plugin-specific channel platforms — they already work transparently through this code path since `createChannel()` uses whatever schema is registered.