### PR TITLE
fix(task-stream): inline tool call rendering + reconnect snapshot

### DIFF
--- a/src/client/components/chat/TaskResultCard.tsx
+++ b/src/client/components/chat/TaskResultCard.tsx
@@ -181,13 +181,6 @@ function getStatusConfig(status: DisplayTaskStatus, t: (key: string) => string) 
         label: t('sidebar.tasks.status.pending'),
         animate: true,
       }
-    case 'paused':
-      return {
-        icon: Pause,
-        colorClass: 'text-amber-500',
-        label: t('sidebar.tasks.status.paused'),
-        animate: false,
-      }
   }
 }
 

--- a/src/client/hooks/useTaskDetail.ts
+++ b/src/client/hooks/useTaskDetail.ts
@@ -46,6 +46,7 @@ interface LearningEntry {
 interface TaskDetailResponse {
   task: TaskDetail
   messages: TaskMessage[]
+  streamingMessageId: string | null
   learningsSaved: LearningEntry[]
 }
 
@@ -166,6 +167,20 @@ export function useTaskDetail(taskId: string | null) {
         streamingReasoningRef.current = ''
         streamingToolCallsRef.current = []
         setStreamingToolCalls([])
+      } else if (data.streamingMessageId) {
+        // The server reports an in-flight assistant message and has overlaid
+        // its live in-memory content into the messages list. Pre-seed the
+        // streaming state from it so buffered chat:token events whose
+        // `contentLength` is already covered by the snapshot are skipped
+        // (see handleToken) — avoids double-counting tokens that were
+        // emitted between the SSE connection and fetchDetail resolution.
+        const inflight = merged.find((m) => m.id === data.streamingMessageId)
+        if (inflight && inflight.role === 'assistant') {
+          streamingMessageIdRef.current = inflight.id
+          streamingContentRef.current = inflight.content
+          setIsStreaming(true)
+          setStreamingMessage(inflight)
+        }
       }
       // Allow SSE handlers to process events now that messagesRef is populated,
       // then replay any events that arrived while we were fetching.
@@ -225,10 +240,19 @@ export function useTaskDetail(taskId: string | null) {
   function handleToken(data: Record<string, unknown>) {
     const token = data.token as string
     const messageId = data.messageId as string
+    const contentLength = typeof data.contentLength === 'number' ? data.contentLength : undefined
 
     if (!streamingMessageIdRef.current) {
       seedStreaming(messageId, token)
     } else {
+      // Skip events already incorporated into streamingContentRef. The server
+      // tags each chat:token with the fullContent length AFTER appending — and
+      // the live snapshot returned by fetchDetail is always at a token boundary
+      // (see executeSubKin) — so this comparison is exact and rejects only
+      // tokens the snapshot already covered.
+      if (contentLength !== undefined && contentLength <= streamingContentRef.current.length) {
+        return
+      }
       streamingContentRef.current += token
       if (!batchTimerRef.current) {
         batchTimerRef.current = setTimeout(() => {
@@ -254,12 +278,7 @@ export function useTaskDetail(taskId: string | null) {
       result: undefined,
       status: 'pending',
       timestamp: new Date().toISOString(),
-      // Intentionally omit offset during streaming: the frontend's accumulated
-      // content may not match the backend's fullContent (missed tokens on
-      // reconnect), so offsets would split text at wrong positions.  Without
-      // offsets, MessageBubble uses fallback mode (text block + tools below).
-      // On stream end, fetchDetail returns correct offsets for proper interleaving.
-      offset: undefined,
+      offset: typeof data.contentOffset === 'number' ? data.contentOffset : undefined,
     }
     streamingToolCallsRef.current = [...streamingToolCallsRef.current, item]
     setStreamingToolCalls(streamingToolCallsRef.current)

--- a/src/server/routes/tasks.ts
+++ b/src/server/routes/tasks.ts
@@ -2,7 +2,7 @@ import { Hono } from 'hono'
 import { eq, and, asc } from 'drizzle-orm'
 import { db } from '@/server/db/index'
 import { tasks, messages, kins } from '@/server/db/schema'
-import { getTask, listTasksPaginated, cancelTask, forcePromoteTask, pauseTask, resumeTask, injectIntoTask } from '@/server/services/tasks'
+import { getTask, listTasksPaginated, cancelTask, forcePromoteTask, pauseTask, resumeTask, injectIntoTask, getActiveTaskSnapshot } from '@/server/services/tasks'
 import { fetchCronLearningsByTask } from '@/server/services/cron-learnings'
 import type { AppVariables } from '@/server/app'
 import type { TaskStatus } from '@/shared/types'
@@ -106,6 +106,12 @@ taskRoutes.get('/:id', async (c) => {
       }))
     : []
 
+  // If a stream is currently in-flight, the DB row for the streaming assistant
+  // message lags by up to 500ms of text. Overlay the live snapshot so a client
+  // that opens the modal mid-stream sees content/tool-calls/reasoning aligned
+  // with the offsets emitted via SSE.
+  const snapshot = getActiveTaskSnapshot(taskId)
+
   return c.json({
     task: {
       id: task.id,
@@ -131,19 +137,26 @@ taskRoutes.get('/:id', async (c) => {
       try { toolCalls = m.toolCalls ? JSON.parse(m.toolCalls) : null } catch { /* corrupted */ }
       try { meta = m.metadata ? JSON.parse(m.metadata as string) : null } catch { /* corrupted */ }
       try { reasoning = m.reasoning ? JSON.parse(m.reasoning as string) : null } catch { /* corrupted */ }
+
+      const isStreaming = snapshot && m.id === snapshot.messageId
       return {
         id: m.id,
         role: m.role,
-        content: m.content,
+        content: isStreaming ? snapshot.content : m.content,
         sourceType: m.sourceType,
         sourceId: m.sourceId,
         isRedacted: m.isRedacted,
-        toolCalls,
+        toolCalls: isStreaming
+          ? (snapshot.toolCalls.length > 0 ? snapshot.toolCalls : null)
+          : toolCalls,
         tokenUsage: meta?.tokenUsage ?? null,
-        reasoning,
+        reasoning: isStreaming
+          ? (snapshot.reasoning.length > 0 ? snapshot.reasoning : null)
+          : reasoning,
         createdAt: m.createdAt,
       }
     }),
+    streamingMessageId: snapshot?.messageId ?? null,
     learningsSaved,
   })
 })

--- a/src/server/services/tasks.ts
+++ b/src/server/services/tasks.ts
@@ -57,6 +57,26 @@ export function isTaskStreaming(taskId: string): boolean {
   return activeTaskAbortControllers.has(taskId)
 }
 
+// Live in-memory snapshot of the currently-streaming assistant message per task.
+// The DB is only checkpointed every 500ms of text + at each tool-batch boundary,
+// so a client reconnecting mid-stream would otherwise miss any text emitted
+// between the last checkpoint and connect time, breaking tool-call offset
+// alignment in the UI. Reading this map gives the route handler the live values.
+export interface ActiveTaskStreamSnapshot {
+  messageId: string
+  content: string
+  toolCalls: Array<{ id: string; name: string; args: unknown; result?: unknown; offset: number }>
+  reasoning: Array<{ offset: number; text: string }>
+}
+
+const activeTaskStreams = new Map<string, ActiveTaskStreamSnapshot>()
+
+/** Read-only access to an in-flight task's accumulated content/tool-calls/reasoning.
+ *  The returned arrays are live references held by `executeSubKin` — callers must not mutate them. */
+export function getActiveTaskSnapshot(taskId: string): ActiveTaskStreamSnapshot | undefined {
+  return activeTaskStreams.get(taskId)
+}
+
 /** Build a public avatar URL from a Kin's stored avatar path */
 function kinAvatarUrl(kinId: string, avatarPath: string | null, updatedAt?: Date | null): string | null {
   if (!avatarPath) return null
@@ -595,6 +615,16 @@ async function executeSubKin(taskId: string, isNudge = false) {
     let streamError: Error | null = null
     let lastCheckpointAt = Date.now()
 
+    // In-memory snapshot for clients that connect mid-stream — see activeTaskStreams above.
+    // Arrays are shared by reference so server-side mutations are visible immediately.
+    const streamSnapshot: ActiveTaskStreamSnapshot = {
+      messageId: assistantMessageId,
+      content: '',
+      toolCalls: toolCallsLog,
+      reasoning: reasoningSegments,
+    }
+    activeTaskStreams.set(taskId, streamSnapshot)
+
     // Pre-insert assistant message so it's visible in fetchDetail() during streaming.
     // Content and tool calls will be updated when the stream completes.
     const assistantMsgCreatedAt = new Date()
@@ -701,10 +731,11 @@ async function executeSubKin(taskId: string, isNudge = false) {
           switch (part.type) {
             case 'text-delta': {
               fullContent += part.text
+              streamSnapshot.content = fullContent
               sseManager.sendToKin(task.parentKinId, {
                 type: 'chat:token',
                 kinId: task.parentKinId,
-                data: { messageId: assistantMessageId, token: part.text, taskId },
+                data: { messageId: assistantMessageId, token: part.text, taskId, contentLength: fullContent.length },
               })
 
               // Periodic checkpoint: persist partial content every 500ms so a page
@@ -810,6 +841,7 @@ async function executeSubKin(taskId: string, isNudge = false) {
     }
 
     activeTaskAbortControllers.delete(taskId)
+    activeTaskStreams.delete(taskId)
 
     // Aggregate token usage (awaited so we can persist in metadata + SSE)
     const taskModelId = task.model ?? kinIdentity.model
@@ -960,6 +992,7 @@ async function executeSubKin(taskId: string, isNudge = false) {
       }
     }
   } catch (err) {
+    activeTaskStreams.delete(taskId)
     const errorMsg = err instanceof Error ? err.message : 'Unknown error'
     log.error({ taskId, error: errorMsg }, 'Sub-Kin execution failed')
     // Sub-Kins / tasks have their own ephemeral message stream and don't


### PR DESCRIPTION
## Summary

Fixes the Task Detail modal where, during streaming, all tool calls clustered together and short text snippets were concatenated into one wall — and where opening the modal mid-stream produced inconsistent state.

- **`useTaskDetail` now preserves the server's `contentOffset`** on streaming tool calls. The previous code deliberately discarded it, forcing `MessageBubble.buildContentParts` into fallback mode (text first, tools at the end). The justification (frontend/backend desync risk) is already covered by the existing `readyRef`/`pendingEventsRef` SSE replay gate — `useToolCalls` (regular chat) already preserves the offset; this aligns Task Detail with it.
- **Live in-memory snapshot of the in-flight assistant message.** `executeSubKin` populates `activeTaskStreams: Map<taskId, ...>` (alongside `activeTaskAbortControllers`) holding the current `fullContent`, `toolCallsLog` and `reasoningSegments`. `GET /tasks/:id` overlays this snapshot onto the matching message so a client opening the modal mid-stream sees fresh state instead of the up-to-500ms-stale DB checkpoint.
- **`contentLength` tagging + client filtering to avoid double-counting** on reconnect. `chat:token` SSE events carry `contentLength: fullContent.length` (set right after the append, in the same microtask as the SSE emit — so events and snapshot are always aligned on a token boundary). `handleToken` skips events whose `contentLength` is already covered by `streamingContentRef.current.length`, so any buffered pre-snapshot tokens that get replayed after `fetchDetail` resolves are discarded cleanly.
- **Pre-seeds streaming state** in `fetchDetail` when the route reports `streamingMessageId`, so the streaming bubble renders immediately on reconnect.
- **Drive-by: removes an unreachable duplicate `case 'paused'`** in `TaskResultCard.getStatusConfig` (silences a vite warning).

## Known limitations (not in this PR)

- Tool calls emitted but not yet completed (i.e. in the brief window between `chat:tool-call` SSE emission and `executeToolBatch` completion) are not in the snapshot. A reconnecting client misses them until the next post-batch DB checkpoint. Tolerable — typical exec windows are seconds.
- Reasoning deltas don't have a `contentLength` filter — small double-counting risk on reconnect, only visible inside the thinking dropdown.

## Test plan

- [ ] Long agentic task (many interleaved text + tool calls): verify rendering is interleaved correctly during streaming, not clustered.
- [ ] Open the Task modal mid-stream: verify the bubble appears immediately with live content (not a stale checkpoint), tool calls inline at their offsets, no duplicated text.
- [ ] Cancel/abort a task mid-stream: verify no stale entries in `activeTaskStreams`.
- [ ] Error path (e.g. context too large): verify the `catch` block in `executeSubKin` cleans the snapshot.
- [ ] Final rendering (after `chat:done` + `fetchDetail`) matches the persisted DB state.